### PR TITLE
♻️ refactor: add in-memory caching strategy for OccupancyPredictor

### DIFF
--- a/app/src/main/java/com/example/sd_smart_parking_app/data/repository/OccupancyRepository.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/repository/OccupancyRepository.kt
@@ -30,6 +30,19 @@ class OccupancyRepository {
         .writeTimeout(30, TimeUnit.SECONDS)
         .build()
 
+    private var cachedPrediction: OccupancyPrediction? = null
+    private var cacheTimestamp: Long = 0
+    private var cachedHour: Int = -1
+    private val cacheDurationMs = 30 * 60 * 1000L
+
+    private fun isCacheValid(targetHour: Int): Boolean {
+        val now = System.currentTimeMillis()
+        val isSameHour = cachedHour == targetHour
+        val isNotExpired = (now - cacheTimestamp) < cacheDurationMs
+        val hasData = cachedPrediction != null
+        return hasData && isSameHour && isNotExpired
+    }
+
     // -------------------------------------------------------------------------
     // Guardar datos de ocupación
     // -------------------------------------------------------------------------
@@ -177,6 +190,13 @@ class OccupancyRepository {
 
     suspend fun predictWithAI(targetHour: Int): Result<OccupancyPrediction> {
         return try {
+
+            // Verificar si hay caché válido
+            if (isCacheValid(targetHour)) {
+                Log.d("OccupancyRepository", "Cache hit — returning cached prediction for hour $targetHour")
+                return Result.success(cachedPrediction!!)
+            }
+
             val recentData = getRecentOccupancyData(30).getOrNull() ?: emptyList()
             val hourlyStats = getHourlyOccupancyStats().getOrNull() ?: emptyList()
             val arrivalStats = getVehicleArrivalStats()
@@ -304,6 +324,12 @@ class OccupancyRepository {
                 recommendedTime = predictionJson.getString("recommendedTime"),
                 reasoning = predictionJson.optString("reasoning", "")
             )
+
+            // Guardar en caché
+            cachedPrediction = prediction
+            cacheTimestamp = System.currentTimeMillis()
+            cachedHour = targetHour
+            Log.d("OccupancyRepository", "Cache updated for hour $targetHour")  
 
             Log.d("OccupancyRepository", "AI Prediction for hour $targetHour: ${prediction.predictedOccupancy}%")
             Result.success(prediction)


### PR DESCRIPTION
## Summary
This PR implements an in-memory caching strategy for the OccupancyPredictor AI feature to reduce unnecessary calls to the Claude API and improve response time for the user.

## Problem
Every time the user opened the HomeScreen, a new call to the Claude API was triggered regardless of whether the prediction had already been calculated recently. This caused:
- Unnecessary API costs on every app load
- Several seconds of loading time on every HomeScreen visit

## Solution
An in-memory cache was implemented directly in `OccupancyRepository.kt` that stores the last prediction returned by Claude along with the hour it was generated for and the timestamp of when it was obtained.

## How it works
Before making a call to Claude, the system validates three conditions:
1. There is a cached prediction available
2. The cached prediction is for the same hour being requested
3. The cached prediction was obtained less than 30 minutes ago

If all three conditions are met, the cached result is returned instantly without calling Claude. If any condition fails, a new call to Claude is made and the result is saved in cache before returning it.

## Files Modified
- `OccupancyRepository.kt` → added 4 cache variables, `isCacheValid()` method, cache verification at the start of `predictWithAI()`, and cache update block before returning the prediction

## Notes
- The cache is in-memory only, meaning it resets when the app is fully closed and reopened. This is intentional and acceptable behavior since a fresh prediction on app restart is reasonable.
- Cache duration is set to 30 minutes, which balances prediction freshness with API cost reduction.
- No changes were made to any other files — the caching logic is fully contained within `OccupancyRepository.kt`.