### PR TITLE
feat: add profile photo with Coil image caching and Firebase Storage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,4 +89,10 @@ dependencies {
 
     // Gson para parseo JSON
     implementation("com.google.code.gson:gson:2.10.1")
+
+    // Coil para caché de imágenes
+    implementation("io.coil-kt:coil-compose:2.5.0")
+
+    // Firebase Storage
+    implementation("com.google.firebase:firebase-storage")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -30,6 +32,15 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/sd_smart_parking_app/data/model/ParkingData.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/model/ParkingData.kt
@@ -34,7 +34,8 @@ data class UserProfile(
     var phone: String = "",
     var role: String = "driver",
     var cars: List<UserCar> = emptyList(),
-    var createdAt: Timestamp? = null
+    var createdAt: Timestamp? = null,
+    var photoURL: String = ""
 )
 
 data class Floor(

--- a/app/src/main/java/com/example/sd_smart_parking_app/data/repository/ParkingRepository.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/repository/ParkingRepository.kt
@@ -10,6 +10,8 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.firestore.Source
 import com.google.firebase.firestore.firestore
+import android.net.Uri
+import com.google.firebase.storage.FirebaseStorage
 
 class ParkingRepository private constructor(private val appContext: Context? = null) {
     private val db = Firebase.firestore
@@ -100,5 +102,31 @@ class ParkingRepository private constructor(private val appContext: Context? = n
 
     fun logout() {
         auth.signOut()
+    }
+
+    fun uploadProfilePhoto(
+        uid: String,
+        photoUri: Uri,
+        onSuccess: (String) -> Unit,
+        onError: (Exception) -> Unit
+    ) {
+        val storage = FirebaseStorage.getInstance()
+        val photoRef = storage.reference.child("profile_photos/$uid.jpg")
+
+        photoRef.putFile(photoUri)
+            .addOnSuccessListener {
+                photoRef.downloadUrl
+                    .addOnSuccessListener { downloadUri ->
+                        onSuccess(downloadUri.toString())
+                    }
+                    .addOnFailureListener { e -> onError(e) }
+            }
+            .addOnFailureListener { e -> onError(e) }
+    }
+
+    fun updateUserPhotoURL(uid: String, photoURL: String, onComplete: (Boolean) -> Unit) {
+        db.collection("users").document(uid)
+            .update("photoURL", photoURL)
+            .addOnCompleteListener { task -> onComplete(task.isSuccessful) }
     }
 }

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/profile/ProfileScreen.kt
@@ -1,6 +1,12 @@
 package com.example.sd_smart_parking_app.ui.screens.profile
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,9 +16,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -27,11 +35,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.example.sd_smart_parking_app.ui.theme.BackgroundLightGray
 import com.example.sd_smart_parking_app.ui.theme.BackgroundWhite
 import com.example.sd_smart_parking_app.ui.theme.CornerRadius
@@ -45,7 +60,9 @@ import com.example.sd_smart_parking_app.ui.theme.Typography
 import com.example.sd_smart_parking_app.ui.theme.WarningYellow
 import com.example.sd_smart_parking_app.ui.theme.White
 import com.example.sd_smart_parking_app.viewmodel.AuthViewModel
+import com.example.sd_smart_parking_app.viewmodel.PhotoUploadState
 import com.example.sd_smart_parking_app.viewmodel.ProfileViewModel
+import java.io.File
 
 @Composable
 fun ProfileScreen(
@@ -56,7 +73,61 @@ fun ProfileScreen(
 ) {
     val userProfile by viewModel.userProfile.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val photoUploadState by viewModel.photoUploadState.collectAsState()
     var showLogoutDialog by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+
+    // URI temporal para la foto tomada con la cámara
+    var tempPhotoUri by remember { mutableStateOf<Uri?>(null) }
+
+    // Launcher para tomar foto con la cámara
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture()
+    ) { success ->
+        if (success) {
+            tempPhotoUri?.let { uri ->
+                viewModel.uploadProfilePhoto(uri)
+            }
+        }
+    }
+
+    // Launcher para solicitar permiso de cámara
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            val photoFile = File.createTempFile("profile_photo", ".jpg", context.cacheDir)
+            val uri = FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.provider",
+                photoFile
+            )
+            tempPhotoUri = uri
+            cameraLauncher.launch(uri)
+        }
+    }
+
+    // Función para abrir la cámara
+    fun openCamera() {
+        when {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED -> {
+                val photoFile = File.createTempFile("profile_photo", ".jpg", context.cacheDir)
+                val uri = FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.provider",
+                    photoFile
+                )
+                tempPhotoUri = uri
+                cameraLauncher.launch(uri)
+            }
+            else -> {
+                permissionLauncher.launch(Manifest.permission.CAMERA)
+            }
+        }
+    }
 
     // Dialog de confirmación de logout
     if (showLogoutDialog) {
@@ -67,7 +138,6 @@ fun ProfileScreen(
             confirmButton = {
                 Button(
                     onClick = {
-                        // Limpiar Remember Me y hacer logout
                         authViewModel.signOut()
                         showLogoutDialog = false
                         onNavigateToLogin()
@@ -106,7 +176,7 @@ fun ProfileScreen(
                     .padding(paddingValues)
                     .verticalScroll(rememberScrollState())
             ) {
-                // Header con botón de logout mejorado
+                // Header con botón de logout
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -114,25 +184,15 @@ fun ProfileScreen(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    // Columna de textos (Izquierda)
-                    Column(
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Text(
-                            text = "Profile",
-                            style = Typography.headlineLarge
-                        )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(text = "Profile", style = Typography.headlineLarge)
                         Text(
                             text = "Manage your account and preferences",
                             style = Typography.bodySmall,
                             modifier = Modifier.padding(top = Spacing.xs)
                         )
                     }
-
-                    // Botón de Logout Mejorado (Derecha)
-                    IconButton(
-                        onClick = { showLogoutDialog = true }
-                    ) {
+                    IconButton(onClick = { showLogoutDialog = true }) {
                         Icon(
                             imageVector = Icons.Default.Logout,
                             contentDescription = "Logout",
@@ -142,14 +202,12 @@ fun ProfileScreen(
                     }
                 }
 
-                // Card de perfil del usuario (Amarillo)
+                // Card de perfil del usuario
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = Spacing.lg),
-                    colors = CardDefaults.cardColors(
-                        containerColor = WarningYellow
-                    ),
+                    colors = CardDefaults.cardColors(containerColor = WarningYellow),
                     shape = RoundedCornerShape(CornerRadius.lg),
                     elevation = CardDefaults.cardElevation(defaultElevation = Elevation.md)
                 ) {
@@ -158,7 +216,6 @@ fun ProfileScreen(
                             .fillMaxWidth()
                             .padding(Spacing.lg)
                     ) {
-                        // Nombre de usuario y avatar
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -170,17 +227,69 @@ fun ProfileScreen(
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(Spacing.md)
                             ) {
-                                // Avatar
+                                // Avatar con foto de perfil usando Coil
                                 Box(
-                                    modifier = Modifier
-                                        .size(56.dp)
-                                        .background(
-                                            color = White,
-                                            shape = RoundedCornerShape(50.dp)
-                                        ),
+                                    modifier = Modifier.size(56.dp),
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    Text("👤", fontSize = 28.sp)
+                                    if (userProfile.photoURL.isNotEmpty()) {
+                                        // Mostrar foto de perfil con Coil
+                                        AsyncImage(
+                                            model = ImageRequest.Builder(context)
+                                                .data(userProfile.photoURL)
+                                                .crossfade(true)
+                                                .build(),
+                                            contentDescription = "Profile Photo",
+                                            modifier = Modifier
+                                                .size(56.dp)
+                                                .clip(CircleShape)
+                                                .clickable { openCamera() },
+                                            contentScale = ContentScale.Crop
+                                        )
+                                    } else {
+                                        // Mostrar emoji por defecto si no hay foto
+                                        Box(
+                                            modifier = Modifier
+                                                .size(56.dp)
+                                                .background(
+                                                    color = White,
+                                                    shape = CircleShape
+                                                )
+                                                .clickable { openCamera() },
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            if (photoUploadState is PhotoUploadState.Loading) {
+                                                CircularProgressIndicator(
+                                                    modifier = Modifier.size(24.dp),
+                                                    color = WarningYellow,
+                                                    strokeWidth = 2.dp
+                                                )
+                                            } else {
+                                                Text("👤", fontSize = 28.sp)
+                                            }
+                                        }
+                                    }
+
+                                    // Icono de cámara superpuesto
+                                    if (photoUploadState !is PhotoUploadState.Loading) {
+                                        Box(
+                                            modifier = Modifier
+                                                .size(20.dp)
+                                                .background(
+                                                    color = MediumGray,
+                                                    shape = CircleShape
+                                                )
+                                                .align(Alignment.BottomEnd),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.CameraAlt,
+                                                contentDescription = "Take photo",
+                                                tint = White,
+                                                modifier = Modifier.size(12.dp)
+                                            )
+                                        }
+                                    }
                                 }
 
                                 Column {
@@ -193,33 +302,36 @@ fun ProfileScreen(
                                         text = userProfile.email.ifEmpty { "user@email.com" },
                                         style = Typography.bodySmall
                                     )
+                                    // Mensaje de estado de subida
+                                    when (photoUploadState) {
+                                        is PhotoUploadState.Success -> Text(
+                                            text = "✅ Photo updated!",
+                                            style = Typography.bodySmall,
+                                            color = androidx.compose.ui.graphics.Color(0xFF2E7D32)
+                                        )
+                                        is PhotoUploadState.Error -> Text(
+                                            text = "❌ ${(photoUploadState as PhotoUploadState.Error).message}",
+                                            style = Typography.bodySmall,
+                                            color = ErrorRed
+                                        )
+                                        else -> {}
+                                    }
                                 }
                             }
 
-                            // Botón de editar
                             IconButton(onClick = { }) {
                                 Text("✏️", fontSize = 20.sp)
                             }
                         }
 
-                        // Estadísticas (Simuladas por ahora)
+                        // Estadísticas
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth(),
+                            modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceEvenly
                         ) {
-                            StatisticItem(
-                                label = "Total Visits",
-                                value = "0"
-                            )
-                            StatisticItem(
-                                label = "Avg Wait (min)",
-                                value = "0"
-                            )
-                            StatisticItem(
-                                label = "Avg Travel\nmin",
-                                value = "0"
-                            )
+                            StatisticItem(label = "Total Visits", value = "0")
+                            StatisticItem(label = "Avg Wait (min)", value = "0")
+                            StatisticItem(label = "Avg Travel\nmin", value = "0")
                         }
                     }
                 }
@@ -233,33 +345,14 @@ fun ProfileScreen(
                         style = Typography.headlineSmall,
                         modifier = Modifier.padding(bottom = Spacing.md)
                     )
-
-                    // Card de Email
-                    AccountCard(
-                        icon = "📧",
-                        label = "Email",
-                        value = userProfile.email.ifEmpty { "Not set" }
-                    )
-
-                    // Card de Teléfono
-                    AccountCard(
-                        icon = "📱",
-                        label = "Phone",
-                        value = userProfile.phone.ifEmpty { "Not set" }
-                    )
-
-                    // Card de Vehículo (Muestra el primer carro si existe)
+                    AccountCard(icon = "📧", label = "Email", value = userProfile.email.ifEmpty { "Not set" })
+                    AccountCard(icon = "📱", label = "Phone", value = userProfile.phone.ifEmpty { "Not set" })
                     val vehicleInfo = if (userProfile.cars.isNotEmpty()) {
                         "${userProfile.cars[0].plate} • ${userProfile.cars[0].name}"
                     } else {
                         "No vehicle registered"
                     }
-
-                    AccountCard(
-                        icon = "🚗",
-                        label = "Vehicle",
-                        value = vehicleInfo
-                    )
+                    AccountCard(icon = "🚗", label = "Vehicle", value = vehicleInfo)
                 }
 
                 // Sección Preferences
@@ -271,15 +364,9 @@ fun ProfileScreen(
                         style = Typography.headlineSmall,
                         modifier = Modifier.padding(bottom = Spacing.md)
                     )
-
-                    PreferenceCard(
-                        icon = "🔔",
-                        label = "Notifications",
-                        isEnabled = true
-                    )
+                    PreferenceCard(icon = "🔔", label = "Notifications", isEnabled = true)
                 }
 
-                // Espaciado inferior
                 Box(modifier = Modifier.padding(bottom = Spacing.lg))
             }
         }
@@ -287,45 +374,22 @@ fun ProfileScreen(
 }
 
 @Composable
-fun StatisticItem(
-    label: String,
-    value: String
-) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = value,
-            style = Typography.displaySmall,
-            fontWeight = FontWeight.Bold
-        )
-        Text(
-            text = label,
-            style = Typography.bodySmall,
-            modifier = Modifier.padding(top = Spacing.xs)
-        )
+fun StatisticItem(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = value, style = Typography.displaySmall, fontWeight = FontWeight.Bold)
+        Text(text = label, style = Typography.bodySmall, modifier = Modifier.padding(top = Spacing.xs))
     }
 }
 
 @Composable
-fun AccountCard(
-    icon: String,
-    label: String,
-    value: String
-) {
+fun AccountCard(icon: String, label: String, value: String) {
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(bottom = Spacing.md),
-        colors = CardDefaults.cardColors(
-            containerColor = BackgroundLightGray
-        ),
+        modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.md),
+        colors = CardDefaults.cardColors(containerColor = BackgroundLightGray),
         shape = RoundedCornerShape(CornerRadius.md)
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(Spacing.lg),
+            modifier = Modifier.fillMaxWidth().padding(Spacing.lg),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -334,54 +398,30 @@ fun AccountCard(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.md)
             ) {
                 Box(
-                    modifier = Modifier
-                        .size(40.dp)
-                        .background(
-                            color = White,
-                            shape = RoundedCornerShape(50.dp)
-                        ),
+                    modifier = Modifier.size(40.dp).background(color = White, shape = RoundedCornerShape(50.dp)),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(icon, fontSize = 18.sp)
                 }
-
                 Column {
-                    Text(
-                        text = label,
-                        style = Typography.bodySmall
-                    )
-                    Text(
-                        text = value,
-                        style = Typography.bodyMedium,
-                        modifier = Modifier.padding(top = Spacing.xs)
-                    )
+                    Text(text = label, style = Typography.bodySmall)
+                    Text(text = value, style = Typography.bodyMedium, modifier = Modifier.padding(top = Spacing.xs))
                 }
             }
-
             Text("→", fontSize = 20.sp)
         }
     }
 }
 
 @Composable
-fun PreferenceCard(
-    icon: String,
-    label: String,
-    isEnabled: Boolean
-) {
+fun PreferenceCard(icon: String, label: String, isEnabled: Boolean) {
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(bottom = Spacing.md),
-        colors = CardDefaults.cardColors(
-            containerColor = BackgroundLightGray
-        ),
+        modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.md),
+        colors = CardDefaults.cardColors(containerColor = BackgroundLightGray),
         shape = RoundedCornerShape(CornerRadius.md)
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(Spacing.lg),
+            modifier = Modifier.fillMaxWidth().padding(Spacing.lg),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -390,30 +430,18 @@ fun PreferenceCard(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.md)
             ) {
                 Box(
-                    modifier = Modifier
-                        .size(40.dp)
-                        .background(
-                            color = White,
-                            shape = RoundedCornerShape(50.dp)
-                        ),
+                    modifier = Modifier.size(40.dp).background(color = White, shape = RoundedCornerShape(50.dp)),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(icon, fontSize = 18.sp)
                 }
-
-                Text(
-                    text = label,
-                    style = Typography.bodyMedium
-                )
+                Text(text = label, style = Typography.bodyMedium)
             }
-
             Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .background(
-                        color = if (isEnabled) com.example.sd_smart_parking_app.ui.theme.HighAvailabilityGreen else BackgroundLightGray,
-                        shape = RoundedCornerShape(50.dp)
-                    ),
+                modifier = Modifier.size(40.dp).background(
+                    color = if (isEnabled) com.example.sd_smart_parking_app.ui.theme.HighAvailabilityGreen else BackgroundLightGray,
+                    shape = RoundedCornerShape(50.dp)
+                ),
                 contentAlignment = Alignment.Center
             ) {
                 Text(if (isEnabled) "✓" else "○", fontSize = 18.sp)
@@ -426,8 +454,6 @@ fun PreferenceCard(
 @Composable
 fun ProfileScreenPreview() {
     SmartParkingTheme {
-        ProfileScreen(
-            onNavigateToLogin = {}
-        )
+        ProfileScreen(onNavigateToLogin = {})
     }
 }

--- a/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/ProfileViewModel.kt
@@ -1,42 +1,73 @@
 package com.example.sd_smart_parking_app.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.sd_smart_parking_app.data.model.UserProfile
 import com.example.sd_smart_parking_app.data.repository.ParkingRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 class ProfileViewModel : ViewModel() {
     private val repository = ParkingRepository.getInstance()
 
-    // Información del perfil
     private val _userProfile = MutableStateFlow(UserProfile())
     val userProfile: StateFlow<UserProfile> = _userProfile
 
-    // Estado de carga
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _photoUploadState = MutableStateFlow<PhotoUploadState>(PhotoUploadState.Idle)
+    val photoUploadState: StateFlow<PhotoUploadState> = _photoUploadState
 
     init {
         fetchUserProfile()
     }
 
-    // Lógica de buscar los datos
     fun fetchUserProfile() {
         _isLoading.value = true
-        // Obtiene el perfil
         repository.getUserProfile { profile ->
             _userProfile.value = profile
             _isLoading.value = false
         }
     }
 
-    // Cerrar sesión
+    fun uploadProfilePhoto(photoUri: Uri) {
+        val uid = repository.getCurrentUserUid() ?: return
+        _photoUploadState.value = PhotoUploadState.Loading
+
+        viewModelScope.launch {
+            repository.uploadProfilePhoto(
+                uid = uid,
+                photoUri = photoUri,
+                onSuccess = { downloadUrl ->
+                    repository.updateUserPhotoURL(uid, downloadUrl) { success ->
+                        if (success) {
+                            _userProfile.value = _userProfile.value.copy(photoURL = downloadUrl)
+                            _photoUploadState.value = PhotoUploadState.Success
+                        } else {
+                            _photoUploadState.value = PhotoUploadState.Error("Failed to update profile")
+                        }
+                    }
+                },
+                onError = { e ->
+                    _photoUploadState.value = PhotoUploadState.Error(e.message ?: "Upload failed")
+                }
+            )
+        }
+    }
+
     fun logout(onLogoutSuccess: () -> Unit) {
         repository.logout()
-        // Limpiamos la información que teníamos en memoria
         _userProfile.value = UserProfile()
-        // Avisamos a la vista que ya puede navegar afuera
         onLogoutSuccess()
     }
+}
+
+sealed class PhotoUploadState {
+    object Idle : PhotoUploadState()
+    object Loading : PhotoUploadState()
+    object Success : PhotoUploadState()
+    data class Error(val message: String) : PhotoUploadState()
 }

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="profile_photos"
+        path="." />
+</paths>


### PR DESCRIPTION
## Summary
This PR implements a profile photo feature that allows users to take a photo directly from their device camera and display it in the Profile screen using Coil for image caching.

## How it works
1. User taps the avatar or the camera icon in the Profile screen
2. The app requests camera permission if not already granted
3. The device camera opens and the user takes a photo
4. The photo is uploaded to **Firebase Storage** under `profile_photos/{uid}.jpg`
5. Firebase Storage returns a public download URL
6. The URL is saved in the `photoURL` field of the user's document in the `users` Firestore collection
7. **Coil** loads and caches the image from the URL automatically every time the Profile screen is displayed

## Coil Integration
- Used `AsyncImage` from Coil with `ImageRequest.Builder` to load the profile photo from the Firebase Storage URL
- Coil handles both memory and disk caching automatically — the image is not re-downloaded on every screen visit
- Added `crossfade(true)` for a smooth image loading transition
- Falls back to the default emoji when no photo URL exists

## Files Modified
- `app/build.gradle.kts` → added Coil (`io.coil-kt:coil-compose:2.5.0`) and Firebase Storage dependencies
- `AndroidManifest.xml` → added `CAMERA` permission and `FileProvider` configuration
- `ParkingData.kt` → added `photoURL` field to `UserProfile` data class
- `ParkingRepository.kt` → added `uploadProfilePhoto()` and `updateUserPhotoURL()` methods
- `ProfileViewModel.kt` → added `uploadProfilePhoto()` method and `PhotoUploadState` sealed class to handle upload lifecycle (Idle, Loading, Success, Error)
- `ProfileScreen.kt` → replaced default emoji avatar with `AsyncImage` from Coil, added camera launcher and permission handling
- `app/src/main/res/xml/file_provider_paths.xml` → new file required for `FileProvider` to share camera photo URIs securely