### PR TITLE
refactor: connect HistoryScreen to Firebase vehicleRecords with real …

### DIFF
--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/history/HistoryScreen.kt
@@ -1,50 +1,38 @@
 package com.example.sd_smart_parking_app.ui.screens.history
 
-import androidx.compose.ui.tooling.preview.Preview
-import com.example.sd_smart_parking_app.ui.theme.SmartParkingTheme
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.sd_smart_parking_app.ui.components.HistoryItem
 import com.example.sd_smart_parking_app.ui.components.ParkingStatus
 import com.example.sd_smart_parking_app.ui.theme.BackgroundWhite
+import com.example.sd_smart_parking_app.ui.theme.NavigationBlue
+import com.example.sd_smart_parking_app.ui.theme.SmartParkingTheme
 import com.example.sd_smart_parking_app.ui.theme.Spacing
 import com.example.sd_smart_parking_app.ui.theme.Typography
+import com.example.sd_smart_parking_app.viewmodel.HistoryViewModel
 
 @Composable
 fun HistoryScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    viewModel: HistoryViewModel = viewModel()
 ) {
-    // Datos de ejemplo del historial
-    val parkingHistory = listOf(
-        Triple(
-            "Mar 3, 2026",
-            "Floor 4 - Space 1-0",
-            ParkingStatus.COMPLETED
-        ) to Triple("12:56", "2 min", "89 min"),
-        Triple(
-            "Mar 2, 2026",
-            "No space available",
-            ParkingStatus.CANCELLED
-        ) to Triple("12:32", "20 min", null),
-        Triple(
-            "Mar 1, 2026",
-            "No space available",
-            ParkingStatus.CANCELLED
-        ) to Triple("10:30", "44 min", null),
-        Triple(
-            "Feb 28, 2026",
-            "Floor 2 - Space 1-3",
-            ParkingStatus.COMPLETED
-        ) to Triple("11:45", "5 min", "120 min")
-    )
+    val uiState by viewModel.uiState.collectAsState()
 
     Scaffold(
         modifier = modifier.fillMaxSize()
@@ -57,39 +45,82 @@ fun HistoryScreen(
                 .verticalScroll(rememberScrollState())
         ) {
             // Header
-            Column(
-                modifier = Modifier.padding(Spacing.lg)
-            ) {
+            Column(modifier = Modifier.padding(Spacing.lg)) {
+                Text(text = "Parking History", style = Typography.headlineLarge)
                 Text(
-                    text = "Parking History",
-                    style = Typography.headlineLarge
-                )
-                Text(
-                    text = "Your recent parking activity",
+                    text = "Your last 10 parking records",
                     style = Typography.bodySmall,
                     modifier = Modifier.padding(top = Spacing.xs)
                 )
             }
 
-            // Lista de historial
-            Column(
-                modifier = Modifier.padding(horizontal = Spacing.lg),
-                verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(Spacing.md)
-            ) {
-                parkingHistory.forEach { (history, times) ->
-                    HistoryItem(
-                        date = history.first,
-                        location = history.second,
-                        status = history.third,
-                        entryTime = times.first,
-                        waitTime = times.second,
-                        duration = times.third
-                    )
+            when {
+                uiState.isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(color = NavigationBlue)
+                    }
+                }
+                uiState.error != null -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Error loading history: ${uiState.error}",
+                            style = Typography.bodyMedium
+                        )
+                    }
+                }
+                uiState.records.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "No parking records found",
+                            style = Typography.bodyMedium
+                        )
+                    }
+                }
+                else -> {
+                    Column(
+                        modifier = Modifier.padding(horizontal = Spacing.lg),
+                        verticalArrangement = Arrangement.spacedBy(Spacing.md)
+                    ) {
+                        uiState.records.forEach { record ->
+                            val status = if (record.type == "exit") {
+                                ParkingStatus.COMPLETED
+                            } else {
+                                ParkingStatus.CANCELLED
+                            }
+
+                            val location = if (record.floor > 0 && record.spotNumber > 0) {
+                                "Floor ${record.floor} - Space ${record.spotNumber}"
+                            } else {
+                                "Parking lot"
+                            }
+
+                            val duration = if (record.type == "exit" && record.durationHours > 0) {
+                                viewModel.formatDuration(record.durationHours)
+                            } else null
+
+                            HistoryItem(
+                                date = viewModel.formatDate(record.timestamp),
+                                location = location,
+                                status = status,
+                                entryTime = viewModel.formatTime(record.timestamp),
+                                waitTime = null,
+                                duration = duration
+                            )
+                        }
+                    }
                 }
             }
 
-            // Espaciado inferior
-            androidx.compose.foundation.layout.Box(modifier = Modifier.padding(bottom = Spacing.lg))
+            Box(modifier = Modifier.padding(bottom = Spacing.lg))
         }
     }
 }

--- a/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/HistoryViewModel.kt
@@ -1,0 +1,117 @@
+package com.example.sd_smart_parking_app.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+data class VehicleRecord(
+    val id: String = "",
+    val type: String = "",
+    val floor: Int = 0,
+    val spotNumber: Int = 0,
+    val durationHours: Double = 0.0,
+    val timestamp: Timestamp? = null,
+    val plate: String = "",
+    val ownerEmail: String = ""
+)
+
+data class HistoryUIState(
+    val records: List<VehicleRecord> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+class HistoryViewModel : ViewModel() {
+
+    private val firestore = FirebaseFirestore.getInstance()
+    private val auth = FirebaseAuth.getInstance()
+
+    private val _uiState = MutableStateFlow(HistoryUIState())
+    val uiState: StateFlow<HistoryUIState> = _uiState
+
+    init {
+        loadHistory()
+    }
+
+    fun loadHistory() {
+        val userEmail = auth.currentUser?.email ?: return
+
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            try {
+                val snapshot = firestore.collection("vehicleRecords")
+                    .whereEqualTo("ownerEmail", userEmail)
+                    .orderBy("timestamp", Query.Direction.DESCENDING)
+                    .limit(10)
+                    .get()
+                    .await()
+
+                val records = snapshot.documents.mapNotNull { doc ->
+                    try {
+                        VehicleRecord(
+                            id = doc.id,
+                            type = doc.getString("type") ?: "",
+                            floor = doc.getLong("floor")?.toInt() ?: 0,
+                            spotNumber = doc.getLong("spotNumber")?.toInt() ?: 0,
+                            durationHours = doc.getDouble("durationHours") ?: 0.0,
+                            timestamp = doc.getTimestamp("timestamp"),
+                            plate = doc.getString("plate") ?: "",
+                            ownerEmail = doc.getString("ownerEmail") ?: ""
+                        )
+                    } catch (e: Exception) {
+                        Log.e("HistoryViewModel", "Error parsing record", e)
+                        null
+                    }
+                }
+
+                _uiState.value = _uiState.value.copy(
+                    records = records,
+                    isLoading = false
+                )
+                Log.d("HistoryViewModel", "Loaded ${records.size} records")
+            } catch (e: Exception) {
+                Log.e("HistoryViewModel", "Error loading history: ${e.message}", e)
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    error = e.message
+                )
+            }
+        }
+    }
+
+    fun formatDate(timestamp: Timestamp?): String {
+        if (timestamp == null) return "Unknown date"
+        val sdf = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+        sdf.timeZone = TimeZone.getTimeZone("America/Bogota")
+        return sdf.format(timestamp.toDate())
+    }
+
+    fun formatTime(timestamp: Timestamp?): String {
+        if (timestamp == null) return "--:--"
+        val sdf = SimpleDateFormat("h:mm a", Locale.getDefault())
+        sdf.timeZone = TimeZone.getTimeZone("America/Bogota")
+        return sdf.format(timestamp.toDate())
+    }
+
+    fun formatDuration(durationHours: Double): String {
+        if (durationHours <= 0) return null.toString()
+        val hours = durationHours.toInt()
+        val minutes = ((durationHours - hours) * 60).toInt()
+        return when {
+            hours > 0 && minutes > 0 -> "${hours}h ${minutes}min"
+            hours > 0 -> "${hours}h"
+            else -> "${minutes}min"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR connects the `HistoryScreen` to Firebase Firestore, replacing the previous static hardcoded data with real user parking records from the `vehicleRecords` collection.

## Changes

### New: HistoryViewModel.kt
- Created `HistoryViewModel` that queries the `vehicleRecords` Firestore collection filtering by the authenticated user's `ownerEmail`
- Fetches the last 10 records ordered by `timestamp` descending
- Added `VehicleRecord` data class to map Firestore documents
- Added `HistoryUIState` to manage loading, error and data states
- Added helper methods `formatDate()`, `formatTime()` and `formatDuration()` to format timestamps and duration values using `America/Bogota` timezone

### Modified: HistoryScreen.kt
- Replaced static hardcoded parking history list with real data from `HistoryViewModel`
- Added loading state with `CircularProgressIndicator`
- Added error state with descriptive message
- Added empty state when no records are found
- Records with `type = "exit"` are shown as `COMPLETED` with duration
- Records with `type = "entry"` are shown as `CANCELLED` without duration

## Firebase
- Created a new composite index on `vehicleRecords` collection for `ownerEmail (ASC) + timestamp (DESC)` required by the query

## Files Modified
- `HistoryScreen.kt` → connected to real Firebase data via HistoryViewModel
- `HistoryViewModel.kt` → new file with Firebase query logic and data formatting