### PR TITLE
feat: add ParkingStats screen with MVVM, Multithreading and Local Storage strategies

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,4 +98,8 @@ dependencies {
 
     // DataStore - Local Storage
     implementation("androidx.datastore:datastore-preferences:1.0.0")
+
+    // Room - Local Relational DB
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
 }

--- a/app/src/main/java/com/example/sd_smart_parking_app/data/ParkingStatsDataStore.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/ParkingStatsDataStore.kt
@@ -1,0 +1,88 @@
+package com.example.sd_smart_parking_app.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+// ── DataStore para metadata del caché de ParkingStats ────────────────────────
+// Siguiendo el patrón del proyecto, esta clase usa el mismo `context.dataStore`
+// que ya está definido en UserPreferencesDataStore.kt mediante la extensión:
+//   val Context.dataStore by preferencesDataStore(name = "user_preferences")
+//
+// Decisión: reutilizamos el mismo DataStore ("user_preferences") en lugar de
+// crear uno nuevo. DataStore es un singleton por nombre — crear dos instancias
+// con el mismo nombre causa corrupción. Al compartir el mismo archivo de
+// preferencias, mantenemos un único punto de verdad para todas las preferencias
+// del usuario, consistente con cómo el proyecto ya gestiona DataStore.
+//
+// Responsabilidad de esta clase: guardar y leer METADATA del caché,
+// NO los stats en sí (esos van en Room). Específicamente:
+//   - lastSyncTimestamp: cuándo fue la última sincronización con Firestore
+//   - cachedUserEmail:   de qué usuario son los datos cacheados en Room
+class ParkingStatsDataStore(private val context: Context) {
+
+    companion object {
+        // Timestamp Unix (ms) de la última sincronización exitosa con Firestore
+        val LAST_SYNC_TIMESTAMP = longPreferencesKey("parking_stats_last_sync")
+
+        // Email del usuario cuyos stats están actualmente en Room.
+        // Si el email actual != este valor, el caché de Room es de otro usuario
+        // y debe ignorarse / limpiarse.
+        val CACHED_USER_EMAIL = stringPreferencesKey("parking_stats_cached_email")
+
+        // Tiempo máximo de vida del caché: 1 hora en milisegundos.
+        // Pasado este tiempo, el ViewModel refrescará desde Firestore aunque
+        // ya haya datos en Room.
+        const val CACHE_TTL_MS = 60 * 60 * 1000L // 1 hora
+    }
+
+    // ── Leer timestamp de última sincronización ───────────────────────────
+    // Retorna 0L si nunca se ha sincronizado (primera apertura).
+    val lastSyncTimestamp: Flow<Long> = context.dataStore.data
+        .map { preferences -> preferences[LAST_SYNC_TIMESTAMP] ?: 0L }
+
+    // ── Leer email del usuario cacheado ───────────────────────────────────
+    // Retorna string vacío si no hay caché previo.
+    val cachedUserEmail: Flow<String> = context.dataStore.data
+        .map { preferences -> preferences[CACHED_USER_EMAIL] ?: "" }
+
+    // ── Guardar timestamp de sincronización exitosa ───────────────────────
+    // Se llama desde el ViewModel justo después de escribir en Room,
+    // garantizando que timestamp y datos Room estén siempre en sincronía.
+    suspend fun saveLastSyncTimestamp(timestamp: Long) {
+        context.dataStore.edit { preferences ->
+            preferences[LAST_SYNC_TIMESTAMP] = timestamp
+        }
+    }
+
+    // ── Guardar email del usuario cacheado ────────────────────────────────
+    // Se llama junto con saveLastSyncTimestamp al completar una sincronización.
+    suspend fun saveCachedUserEmail(email: String) {
+        context.dataStore.edit { preferences ->
+            preferences[CACHED_USER_EMAIL] = email
+        }
+    }
+
+    // ── Verificar si el caché está vigente ────────────────────────────────
+    // Lógica: el caché es válido si fue guardado hace menos de CACHE_TTL_MS.
+    // El ViewModel usa esto para decidir si mostrar Room directamente
+    // o forzar un refresh desde Firestore.
+    fun isCacheValid(lastSync: Long): Boolean {
+        if (lastSync == 0L) return false
+        val age = System.currentTimeMillis() - lastSync
+        return age < CACHE_TTL_MS
+    }
+
+    // ── Limpiar metadata del caché ────────────────────────────────────────
+    // Se llama cuando el usuario cierra sesión, junto con el borrado
+    // del registro en Room. Garantiza que no quede metadata huérfana.
+    suspend fun clearCacheMetadata() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(LAST_SYNC_TIMESTAMP)
+            preferences.remove(CACHED_USER_EMAIL)
+        }
+    }
+}

--- a/app/src/main/java/com/example/sd_smart_parking_app/data/ParkingStatsDatabase.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/ParkingStatsDatabase.kt
@@ -1,0 +1,64 @@
+package com.example.sd_smart_parking_app.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.example.sd_smart_parking_app.data.model.MapTypeConverter
+import com.example.sd_smart_parking_app.data.model.ParkingStatsEntity
+import com.example.sd_smart_parking_app.data.repository.ParkingStatsDao
+
+// ── Base de datos Room ────────────────────────────────────────────────────────
+// Siguiendo el patrón MVVM del proyecto, esta clase vive en la capa `data/`
+// junto a otros servicios de infraestructura como NetworkMonitor,
+// NotificationManager y ParkingNotesDatabaseHelper.
+//
+// Decisión de diseño: Singleton con double-checked locking.
+// Solo existe una instancia de la BD en toda la app. Crear múltiples
+// instancias de RoomDatabase es costoso y puede causar corrupción de datos
+// si dos instancias escriben al mismo tiempo.
+//
+// version = 1: primera versión del esquema. Si en el futuro se agregan
+// columnas, se incrementa la versión y se provee una Migration.
+@Database(
+    entities = [ParkingStatsEntity::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(MapTypeConverter::class)
+abstract class ParkingStatsDatabase : RoomDatabase() {
+
+    // Room genera la implementación concreta de este DAO en tiempo de compilación
+    abstract fun parkingStatsDao(): ParkingStatsDao
+
+    companion object {
+
+        // @Volatile garantiza que el valor de INSTANCE sea siempre visible
+        // a todos los hilos — sin caché de CPU que pueda causar lecturas stale.
+        @Volatile
+        private var INSTANCE: ParkingStatsDatabase? = null
+
+        fun getInstance(context: Context): ParkingStatsDatabase {
+            // Double-checked locking: evita bloquear el hilo cada vez que
+            // se solicita la instancia. Solo bloquea la primera vez.
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: buildDatabase(context).also { INSTANCE = it }
+            }
+        }
+
+        private fun buildDatabase(context: Context): ParkingStatsDatabase {
+            return Room.databaseBuilder(
+                context.applicationContext,  // applicationContext evita memory leaks
+                ParkingStatsDatabase::class.java,
+                "parking_stats_db"           // nombre del archivo .db en disco
+            )
+                // fallbackToDestructiveMigration: si la versión cambia y no hay
+                // Migration definida, Room recrea la BD desde cero en lugar de
+                // crashear. Aceptable para un caché — los datos se recuperan de
+                // Firestore en el siguiente refresh.
+                .fallbackToDestructiveMigration()
+                .build()
+        }
+    }
+}

--- a/app/src/main/java/com/example/sd_smart_parking_app/data/model/ParkingStatsEntity.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/model/ParkingStatsEntity.kt
@@ -1,0 +1,58 @@
+package com.example.sd_smart_parking_app.data.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+// ── Type Converter: Map<String, Double> ↔ String (JSON) ──────────────────────
+// Room solo puede persistir tipos primitivos. El mapa de duraciones por día
+// se serializa a JSON para guardarlo en la columna y se deserializa al leerlo.
+class MapTypeConverter {
+    private val gson = Gson()
+
+    @TypeConverter
+    fun fromMap(map: Map<String, Double>): String =
+        gson.toJson(map)
+
+    @TypeConverter
+    fun toMap(json: String): Map<String, Double> {
+        val type = object : TypeToken<Map<String, Double>>() {}.type
+        return gson.fromJson(json, type) ?: emptyMap()
+    }
+}
+
+// ── Entidad Room ──────────────────────────────────────────────────────────────
+// Representa una fila en la tabla "parking_stats".
+// Decisión: usamos el email del usuario como PrimaryKey porque cada usuario
+// tiene exactamente un set de stats cacheados. Si el usuario cambia, se
+// sobreescribe el registro existente (onConflict = REPLACE en el DAO).
+@Entity(tableName = "parking_stats")
+@TypeConverters(MapTypeConverter::class)
+data class ParkingStatsEntity(
+
+    @PrimaryKey
+    val ownerEmail: String,
+
+    // ── KPIs principales ──────────────────────────────────────────────────
+    val totalSessions: Int,
+    val totalTimeHours: Double,
+    val totalPaidCOP: Double,
+    val avgSessionHours: Double,
+
+    // ── Insights ──────────────────────────────────────────────────────────
+    val busiestDay: String,
+    val busiestDaySessions: Int,
+    val favouriteFloor: Int,
+    val favouriteFloorVisits: Int,
+
+    // ── Gráfica (serializada como JSON) ───────────────────────────────────
+    val avgDurationByDay: Map<String, Double>,
+
+    // ── Metadata del caché ────────────────────────────────────────────────
+    // Timestamp Unix (ms) de cuándo se guardaron estos datos.
+    // Usado por el ViewModel para decidir si el caché está vigente.
+    val cachedAt: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/example/sd_smart_parking_app/data/repository/OccupancyRepository.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/repository/OccupancyRepository.kt
@@ -223,19 +223,14 @@ class OccupancyRepository private constructor() {
     suspend fun predictWithAI(targetHour: Int): Result<OccupancyPrediction> {
         return try {
 
-            // Verificar si hay caché válido en el LruCache
+
             if (isCacheValid(targetHour)) {
                 val cached = getCachedPrediction(targetHour)!!
                 Log.d("OccupancyRepository", "Cache hit — returning LruCache prediction for hour $targetHour")
                 return Result.success(cached)
             }
 
-            // -------------------------------------------------------------------------
-            // MULTITHREADING: Dos corrutinas paralelas en Dispatchers.IO
-            // Corrutina 1: obtiene datos recientes de ocupación (parking_occupancy_history)
-            // Corrutina 2: obtiene estadísticas de llegada de vehículos (vehicleRecords)
-            // Ambas corren simultáneamente en hilos separados del pool de IO
-            // -------------------------------------------------------------------------
+
             val recentData: List<OccupancyHistory>
             val hourlyStats: List<HourlyOccupancyStats>
             val arrivalStats: Map<Int, Int>
@@ -244,19 +239,16 @@ class OccupancyRepository private constructor() {
                 Log.d("OccupancyRepository", "Starting parallel Firebase queries on thread: ${Thread.currentThread().name}")
 
                 kotlinx.coroutines.coroutineScope {
-                    // Corrutina anidada 1 — consulta parking_occupancy_history en Dispatchers.IO
                     val recentDataJob = async(Dispatchers.IO) {
                         Log.d("OccupancyRepository", "Coroutine 1 (recentData) running on thread: ${Thread.currentThread().name}")
                         getRecentOccupancyData(30).getOrNull() ?: emptyList<OccupancyHistory>()
                     }
 
-                    // Corrutina anidada 2 — consulta vehicleRecords en Dispatchers.IO
                     val arrivalStatsJob = async(Dispatchers.IO) {
                         Log.d("OccupancyRepository", "Coroutine 2 (arrivalStats) running on thread: ${Thread.currentThread().name}")
                         getVehicleArrivalStats()
                     }
-
-                    // Corrutina anidada 3 — consulta hourly stats en Dispatchers.IO
+                    
                     val hourlyStatsJob = async(Dispatchers.IO) {
                         Log.d("OccupancyRepository", "Coroutine 3 (hourlyStats) running on thread: ${Thread.currentThread().name}")
                         getHourlyOccupancyStats().getOrNull() ?: emptyList<HourlyOccupancyStats>()

--- a/app/src/main/java/com/example/sd_smart_parking_app/data/repository/ParkingStatsDao.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/repository/ParkingStatsDao.kt
@@ -1,0 +1,48 @@
+package com.example.sd_smart_parking_app.data.repository
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.sd_smart_parking_app.data.model.ParkingStatsEntity
+
+// ── DAO (Data Access Object) ──────────────────────────────────────────────────
+// Siguiendo el patrón MVVM del proyecto:
+//   UI (Screen) → ViewModel → Repository → DAO → Room DB
+//
+// El DAO es la capa de acceso a la BD. Define las operaciones SQL disponibles
+// sobre la tabla "parking_stats". El ViewModel nunca toca Room directamente —
+// siempre pasa por aquí.
+//
+// Decisión: todas las funciones son suspend para ejecutarse en Dispatchers.IO
+// sin bloquear el hilo principal, igual que las demás operaciones de datos
+// del proyecto.
+@Dao
+interface ParkingStatsDao {
+
+    // ── Leer stats cacheados para un usuario ──────────────────────────────
+    // Retorna null si no hay caché para ese email (primera vez que abre la app
+    // o si se limpió la BD local).
+    @Query("SELECT * FROM parking_stats WHERE ownerEmail = :email LIMIT 1")
+    suspend fun getStatsByEmail(email: String): ParkingStatsEntity?
+
+    // ── Guardar o actualizar stats ────────────────────────────────────────
+    // OnConflictStrategy.REPLACE: si ya existe un registro para ese email,
+    // lo sobreescribe completamente con los datos frescos de Firestore.
+    // Decisión: REPLACE en lugar de UPDATE para simplificar — siempre
+    // guardamos el objeto completo, nunca parcialmente.
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertOrReplace(entity: ParkingStatsEntity)
+
+    // ── Eliminar stats de un usuario ──────────────────────────────────────
+    // Usado cuando el usuario cierra sesión — limpiamos su caché local
+    // para que otro usuario no vea datos ajenos.
+    @Query("DELETE FROM parking_stats WHERE ownerEmail = :email")
+    suspend fun deleteByEmail(email: String)
+
+    // ── Verificar si existe caché para un usuario ─────────────────────────
+    // Permite al ViewModel saber rápidamente si hay datos locales
+    // sin traer todo el objeto.
+    @Query("SELECT COUNT(*) FROM parking_stats WHERE ownerEmail = :email")
+    suspend fun hasCache(email: String): Int
+}

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/navigation/NavGraph.kt
@@ -24,6 +24,7 @@ import com.google.firebase.analytics.analytics
 import com.google.firebase.analytics.logEvent
 import com.google.firebase.auth.FirebaseAuth
 import com.example.sd_smart_parking_app.ui.screens.notes.ParkingNotesScreen
+import com.example.sd_smart_parking_app.ui.screens.stats.ParkingStatsScreen
 
 // Rutas de navegación
 object NavRoutes {
@@ -37,6 +38,8 @@ object NavRoutes {
     const val HISTORY = "history"
     const val PROFILE = "profile"
     const val PARKING_NOTES = "parking_notes"
+
+    const val PARKING_STATS = "parking_stats"
 }
 
 @Composable
@@ -145,11 +148,22 @@ fun SmartParkingNavGraph(
                     navController.navigate(NavRoutes.LOGIN) {
                         popUpTo(NavRoutes.HOME) { inclusive = true }
                     }
+                },
+                onNavigateToParkingStats = {
+                    navController.navigate(NavRoutes.PARKING_STATS)
                 }
             )
         }
         composable(NavRoutes.PARKING_NOTES) {
             ParkingNotesScreen(
+                onNavigateBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+        composable(NavRoutes.PARKING_STATS) {
+            ParkingStatsScreen(
                 onNavigateBack = {
                     navController.popBackStack()
                 }

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/profile/ProfileScreen.kt
@@ -65,13 +65,16 @@ import com.example.sd_smart_parking_app.viewmodel.AuthViewModel
 import com.example.sd_smart_parking_app.viewmodel.PhotoUploadState
 import com.example.sd_smart_parking_app.viewmodel.ProfileViewModel
 import java.io.File
+import com.example.sd_smart_parking_app.ui.theme.NavigationBlue
 
 @Composable
 fun ProfileScreen(
     modifier: Modifier = Modifier,
     viewModel: ProfileViewModel = viewModel(),
     authViewModel: AuthViewModel = viewModel(),
-    onNavigateToLogin: () -> Unit
+    onNavigateToLogin: () -> Unit,
+
+    onNavigateToParkingStats: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val networkMonitor = remember { NetworkMonitor(context) }
@@ -361,6 +364,50 @@ fun ProfileScreen(
                         "No vehicle registered"
                     }
                     AccountCard(icon = "🚗", label = "Vehicle", value = vehicleInfo)
+                }
+
+                // My Parking Stats button
+                Column(
+                    modifier = Modifier.padding(horizontal = Spacing.lg)
+                ) {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = Spacing.md)
+                            .clickable { onNavigateToParkingStats() },
+                        colors = CardDefaults.cardColors(containerColor = NavigationBlue),
+                        shape = RoundedCornerShape(CornerRadius.md),
+                        elevation = CardDefaults.cardElevation(defaultElevation = Elevation.md)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(Spacing.lg),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(40.dp)
+                                        .background(color = White.copy(alpha = 0.2f), shape = RoundedCornerShape(50.dp)),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text("📊", fontSize = 18.sp)
+                                }
+                                Text(
+                                    text = "My Parking Stats",
+                                    style = Typography.bodyMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = White
+                                )
+                            }
+                            Text("→", fontSize = 20.sp, color = White)
+                        }
+                    }
                 }
 
                 // Preferences

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/stats/ParkingStatsScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/stats/ParkingStatsScreen.kt
@@ -1,0 +1,507 @@
+package com.example.sd_smart_parking_app.ui.screens.stats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.sd_smart_parking_app.ui.theme.BackgroundLightGray
+import com.example.sd_smart_parking_app.ui.theme.BackgroundWhite
+import com.example.sd_smart_parking_app.ui.theme.BorderGray
+import com.example.sd_smart_parking_app.ui.theme.MediumGray
+import com.example.sd_smart_parking_app.ui.theme.NavigationBlue
+import com.example.sd_smart_parking_app.ui.theme.SmartParkingTheme
+import com.example.sd_smart_parking_app.ui.theme.Spacing
+import com.example.sd_smart_parking_app.ui.theme.Typography
+import com.example.sd_smart_parking_app.ui.theme.White
+import com.example.sd_smart_parking_app.viewmodel.ParkingStatsViewModel
+
+// ── Colores locales para los iconos de las KPI cards ──────────────────────────
+private val KpiBlue      = Color(0xFF2979FF)
+private val KpiPurple    = Color(0xFFAB47BC)
+private val KpiGreen     = Color(0xFF43A047)
+private val ChartBlue    = Color(0xFF1565C0)
+private val InsightAmber = Color(0xFFFF8F00)
+private val InsightBlue  = Color(0xFF5C6BC0)
+
+@Composable
+fun ParkingStatsScreen(
+    modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit = {}
+) {
+    val context = LocalContext.current
+    val viewModel: ParkingStatsViewModel = viewModel(
+        factory = object : ViewModelProvider.Factory {
+            override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+                @Suppress("UNCHECKED_CAST")
+                return ParkingStatsViewModel(context) as T
+            }
+        }
+    )
+
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(modifier = modifier.fillMaxSize()) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(BackgroundLightGray)
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+        ) {
+
+            // ── Top bar ───────────────────────────────────────────────────
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(BackgroundWhite)
+                    .padding(horizontal = Spacing.sm, vertical = Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                IconButton(onClick = onNavigateBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+                Text(
+                    text = "My Parking Stats",
+                    style = Typography.headlineMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                IconButton(onClick = { viewModel.loadStats() }) {
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = "Refresh"
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(Spacing.lg))
+
+            when {
+                // ── Cargando ──────────────────────────────────────────────
+                uiState.isLoading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 80.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(color = NavigationBlue)
+                    }
+                }
+
+                // ── Error ─────────────────────────────────────────────────
+                uiState.error != null -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 80.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("⚠️", fontSize = 40.sp)
+                            Spacer(modifier = Modifier.height(Spacing.md))
+                            Text(
+                                text = "Could not load stats",
+                                style = Typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = uiState.error ?: "",
+                                style = Typography.bodySmall,
+                                color = MediumGray,
+                                modifier = Modifier.padding(top = Spacing.xs)
+                            )
+                        }
+                    }
+                }
+
+                // ── Sin sesiones ──────────────────────────────────────────
+                uiState.totalSessions == 0 -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 80.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("🅿️", fontSize = 48.sp)
+                            Spacer(modifier = Modifier.height(Spacing.md))
+                            Text(
+                                text = "No parking sessions yet",
+                                style = Typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = "Your stats will appear here after your first session.",
+                                style = Typography.bodySmall,
+                                color = MediumGray,
+                                modifier = Modifier.padding(top = Spacing.xs)
+                            )
+                        }
+                    }
+                }
+
+                // ── Contenido principal ───────────────────────────────────
+                else -> {
+                    StatsContent(viewModel = viewModel)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(Spacing.lg))
+        }
+    }
+}
+
+// ── Contenido principal ────────────────────────────────────────────────────────
+@Composable
+private fun StatsContent(viewModel: ParkingStatsViewModel) {
+    val s by viewModel.uiState.collectAsState()
+
+    // ── 3 KPI cards ──────────────────────────────────────────────────────
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+    ) {
+        KpiCard(
+            modifier = Modifier.weight(1f),
+            icon = "🚗",
+            iconTint = KpiBlue,
+            value = s.totalSessions.toString(),
+            label = "Sessions"
+        )
+        KpiCard(
+            modifier = Modifier.weight(1f),
+            icon = "🕐",
+            iconTint = KpiPurple,
+            value = viewModel.formatTotalTime(s.totalTimeHours),
+            label = "Total Time"
+        )
+        KpiCard(
+            modifier = Modifier.weight(1f),
+            icon = "¢",
+            iconTint = KpiGreen,
+            value = viewModel.formatCOP(s.totalPaidCOP),
+            label = "Total Paid"
+        )
+    }
+
+    Spacer(modifier = Modifier.height(Spacing.md))
+
+    // ── Duración promedio ─────────────────────────────────────────────────
+    AvgSessionCard(
+        label = "Average Session",
+        value = viewModel.formatTotalTime(s.avgSessionHours)
+    )
+
+    Spacer(modifier = Modifier.height(Spacing.md))
+
+    // ── Insights: Busiest day + Favourite floor ───────────────────────────
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+    ) {
+        InsightCard(
+            modifier = Modifier.weight(1f),
+            icon = "📅",
+            iconTint = InsightAmber,
+            title = "Busiest Day",
+            mainValue = s.busiestDay,
+            subValue = "${s.busiestDaySessions} session${if (s.busiestDaySessions != 1) "s" else ""}"
+        )
+        InsightCard(
+            modifier = Modifier.weight(1f),
+            icon = "🏢",
+            iconTint = InsightBlue,
+            title = "Favourite Floor",
+            mainValue = if (s.favouriteFloor > 0) "Floor ${s.favouriteFloor}" else "—",
+            subValue = "${s.favouriteFloorVisits} visit${if (s.favouriteFloorVisits != 1) "s" else ""}"
+        )
+    }
+
+    Spacer(modifier = Modifier.height(Spacing.md))
+
+    // ── Gráfica de barras ─────────────────────────────────────────────────
+    val chartData = if (s.avgDurationByDay.isNotEmpty()) {
+        s.avgDurationByDay
+    } else {
+        listOf("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+            .associateWith { 0.0 }
+    }
+    AvgDurationBarChart(
+        data = chartData,
+        maxValue = viewModel.maxAvgDuration(chartData),
+        formatLabel = { viewModel.formatAvgDuration(it) },
+        shortDay = { viewModel.shortDay(it) }
+    )
+}
+
+// ── KPI Card ───────────────────────────────────────────────────────────────────
+@Composable
+private fun KpiCard(
+    modifier: Modifier = Modifier,
+    icon: String,
+    iconTint: Color,
+    value: String,
+    label: String
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = BackgroundWhite),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = Spacing.md, horizontal = Spacing.sm),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(iconTint.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = icon, fontSize = 18.sp)
+            }
+            Text(
+                text = value,
+                style = Typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = Color.Black
+            )
+            Text(
+                text = label,
+                style = Typography.bodySmall,
+                color = MediumGray
+            )
+        }
+    }
+}
+
+// ── Average Session Card ───────────────────────────────────────────────────────
+@Composable
+private fun AvgSessionCard(label: String, value: String) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg),
+        colors = CardDefaults.cardColors(containerColor = BackgroundWhite),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.lg, vertical = Spacing.lg),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(
+                    text = label,
+                    style = Typography.bodySmall,
+                    color = MediumGray
+                )
+                Text(
+                    text = value,
+                    fontSize = 36.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = NavigationBlue
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape)
+                    .background(NavigationBlue.copy(alpha = 0.08f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("⏱", fontSize = 26.sp)
+            }
+        }
+    }
+}
+
+// ── Insight Card ───────────────────────────────────────────────────────────────
+@Composable
+private fun InsightCard(
+    modifier: Modifier = Modifier,
+    icon: String,
+    iconTint: Color,
+    title: String,
+    mainValue: String,
+    subValue: String
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = BackgroundWhite),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.xs)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(iconTint.copy(alpha = 0.12f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(text = icon, fontSize = 14.sp)
+                }
+                Text(
+                    text = title,
+                    style = Typography.bodySmall,
+                    color = MediumGray
+                )
+            }
+            Text(
+                text = mainValue,
+                style = Typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = Color.Black
+            )
+            Text(
+                text = subValue,
+                style = Typography.bodySmall,
+                color = MediumGray
+            )
+        }
+    }
+}
+
+// ── Bar Chart ──────────────────────────────────────────────────────────────────
+@Composable
+private fun AvgDurationBarChart(
+    data: Map<String, Double>,
+    maxValue: Double,
+    formatLabel: (Double) -> String,
+    shortDay: (String) -> String
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg),
+        colors = CardDefaults.cardColors(containerColor = BackgroundWhite),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.lg)
+        ) {
+            Text(
+                text = "Avg Duration by Day of Week",
+                style = Typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.height(Spacing.lg))
+
+            data.forEach { (day, avgHours) ->
+                val fraction = if (avgHours == 0.0) 0.04f
+                else (avgHours / maxValue).coerceIn(0.0, 1.0).toFloat()
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = Spacing.sm),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = shortDay(day),
+                        style = Typography.bodySmall,
+                        color = MediumGray,
+                        modifier = Modifier.width(36.dp)
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.sm))
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(20.dp)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(BorderGray)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth(fraction)
+                                .height(20.dp)
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(ChartBlue)
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(Spacing.sm))
+                    Text(
+                        text = formatLabel(avgHours),
+                        style = Typography.bodySmall,
+                        color = MediumGray,
+                        modifier = Modifier.width(44.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun ParkingStatsScreenPreview() {
+    SmartParkingTheme {
+        ParkingStatsScreen()
+    }
+}

--- a/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/ParkingStatsViewModel.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/ParkingStatsViewModel.kt
@@ -1,0 +1,447 @@
+package com.example.sd_smart_parking_app.viewmodel
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.sd_smart_parking_app.data.ParkingStatsDatabase
+import com.example.sd_smart_parking_app.data.ParkingStatsDataStore
+import com.example.sd_smart_parking_app.data.model.ParkingStatsEntity
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.File
+import java.util.Calendar
+import java.util.TimeZone
+
+data class ParkingStatsUIState(
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val error: String? = null,
+    val totalSessions: Int = 0,
+    val totalTimeHours: Double = 0.0,
+    val totalPaidCOP: Double = 0.0,
+    val avgSessionHours: Double = 0.0,
+    val busiestDay: String = "",
+    val busiestDaySessions: Int = 0,
+    val favouriteFloor: Int = 0,
+    val favouriteFloorVisits: Int = 0,
+    val avgDurationByDay: Map<String, Double> = emptyMap(),
+    val lastSyncTimestamp: Long = 0L
+)
+
+// Modelo de resultado de cálculo — separa responsabilidades entre IO y Default
+private data class ComputedStats(
+    val totalSessions: Int,
+    val totalTimeHours: Double,
+    val totalPaidCOP: Double,
+    val avgSessionHours: Double,
+    val busiestDay: String,
+    val busiestDaySessions: Int,
+    val favouriteFloor: Int,
+    val favouriteFloorVisits: Int,
+    val avgDurationByDay: Map<String, Double>
+)
+
+class ParkingStatsViewModel(private val context: Context) : ViewModel() {
+
+    private val firestore = FirebaseFirestore.getInstance()
+    private val auth = FirebaseAuth.getInstance()
+
+    // ── Capas de Local Storage ────────────────────────────────────────────────
+    // 1. Room: BD relacional para los stats calculados
+    private val db = ParkingStatsDatabase.getInstance(context)
+    private val dao = db.parkingStatsDao()
+
+    // 2. DataStore: metadata del caché (timestamp + email)
+    private val dataStore = ParkingStatsDataStore(context)
+
+    // 3. Archivo local JSON: respaldo offline de los stats
+    private val statsFile = File(context.filesDir, "parking_stats_backup.json")
+
+    private val _uiState = MutableStateFlow(ParkingStatsUIState())
+    val uiState: StateFlow<ParkingStatsUIState> = _uiState
+
+    private val hourlyRateCOP = 3_000.0
+    private val dayOrder = listOf(
+        "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+    )
+
+    init {
+        loadStats()
+    }
+
+    fun loadStats() {
+        val userEmail = auth.currentUser?.email ?: return
+
+        // ── CORRUTINA 1: Main — orquestadora ─────────────────────────────────
+        // Coordina las 3 capas de local storage + Firestore.
+        // Decisión: viewModelScope garantiza cancelación automática al destruir
+        // el ViewModel, evitando memory leaks.
+        viewModelScope.launch {
+
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            Log.d("ParkingStatsVM", "[Main] Orquestadora iniciada — hilo: ${Thread.currentThread().name}")
+
+            // ── PASO 1: Leer caché de Room (Dispatchers.IO) ───────────────────
+            // Intentamos mostrar datos locales inmediatamente mientras
+            // decidimos si necesitamos ir a Firestore.
+            val cachedEntity = async(Dispatchers.IO) {
+                Log.d("ParkingStatsVM", "[IO] Leyendo Room — hilo: ${Thread.currentThread().name}")
+                dao.getStatsByEmail(userEmail)
+            }.await()
+
+            // ── PASO 2: Leer metadata del caché (DataStore) ───────────────────
+            val lastSync = dataStore.lastSyncTimestamp.first()
+            val cachedEmail = dataStore.cachedUserEmail.first()
+            val cacheValid = dataStore.isCacheValid(lastSync) && cachedEmail == userEmail
+
+            Log.d("ParkingStatsVM", "[Main] Caché válido: $cacheValid | lastSync: $lastSync | email match: ${cachedEmail == userEmail}")
+
+            // Si hay caché de Room para este usuario, mostrarlo inmediatamente
+            if (cachedEntity != null && cachedEmail == userEmail) {
+                Log.d("ParkingStatsVM", "[Main] Mostrando datos desde Room")
+                withContext(Dispatchers.Main) {
+                    _uiState.value = cachedEntity.toUIState(isRefreshing = !cacheValid)
+                }
+            }
+
+            // Si el caché es válido y los datos ya están en pantalla, no vamos a Firestore
+            if (cacheValid && cachedEntity != null) {
+                Log.d("ParkingStatsVM", "[Main] Caché vigente — omitiendo Firestore")
+                _uiState.value = _uiState.value.copy(isLoading = false, isRefreshing = false)
+                return@launch
+            }
+
+            // ── PASO 3: Consultar Firestore (Dispatchers.IO) ──────────────────
+            // Solo llegamos aquí si el caché expiró o no existe.
+            try {
+                val recordsDeferred = async(Dispatchers.IO) {
+                    Log.d("ParkingStatsVM", "[IO] Consultando Firestore — hilo: ${Thread.currentThread().name}")
+
+                    val snapshot = firestore.collection("vehicleRecords")
+                        .whereEqualTo("ownerEmail", userEmail)
+                        .whereEqualTo("type", "exit")
+                        .get()
+                        .await()
+
+                    snapshot.documents.mapNotNull { doc ->
+                        try {
+                            VehicleRecord(
+                                id = doc.id,
+                                type = doc.getString("type") ?: "",
+                                floor = doc.getLong("floor")?.toInt() ?: 0,
+                                spotNumber = doc.getLong("spotNumber")?.toInt() ?: 0,
+                                durationHours = doc.getDouble("durationHours") ?: 0.0,
+                                timestamp = doc.getTimestamp("timestamp"),
+                                plate = doc.getString("plate") ?: "",
+                                ownerEmail = doc.getString("ownerEmail") ?: ""
+                            )
+                        } catch (e: Exception) {
+                            Log.e("ParkingStatsVM", "[IO] Error parseando documento", e)
+                            null
+                        }
+                    }.also {
+                        Log.d("ParkingStatsVM", "[IO] ${it.size} registros obtenidos de Firestore")
+                    }
+                }
+
+                val records = recordsDeferred.await()
+
+                if (records.isEmpty()) {
+                    Log.d("ParkingStatsVM", "[Main] Sin registros en Firestore")
+                    withContext(Dispatchers.Main) {
+                        _uiState.value = ParkingStatsUIState(isLoading = false)
+                    }
+                    return@launch
+                }
+
+                // ── PASO 4: Calcular stats (Dispatchers.Default) ──────────────
+                // Operaciones CPU-intensivas en el pool de cómputo.
+                val statsDeferred = async(Dispatchers.Default) {
+                    Log.d("ParkingStatsVM", "[Default] Calculando stats — hilo: ${Thread.currentThread().name}")
+
+                    val bogota = TimeZone.getTimeZone("America/Bogota")
+
+                    val totalSessions   = records.size
+                    val totalTimeHours  = records.sumOf { it.durationHours }
+                    val totalPaidCOP    = totalTimeHours * hourlyRateCOP
+                    val avgSessionHours = totalTimeHours / totalSessions
+
+                    val sessionsByDay = records
+                        .mapNotNull { record ->
+                            record.timestamp?.toDate()?.let { date ->
+                                val cal = Calendar.getInstance(bogota)
+                                cal.time = date
+                                when (cal.get(Calendar.DAY_OF_WEEK)) {
+                                    Calendar.MONDAY    -> "Monday"
+                                    Calendar.TUESDAY   -> "Tuesday"
+                                    Calendar.WEDNESDAY -> "Wednesday"
+                                    Calendar.THURSDAY  -> "Thursday"
+                                    Calendar.FRIDAY    -> "Friday"
+                                    Calendar.SATURDAY  -> "Saturday"
+                                    Calendar.SUNDAY    -> "Sunday"
+                                    else               -> null
+                                }
+                            }
+                        }
+                        .groupingBy { it }
+                        .eachCount()
+
+                    val busiestEntry       = sessionsByDay.maxByOrNull { it.value }
+                    val busiestDay         = busiestEntry?.key ?: ""
+                    val busiestDaySessions = busiestEntry?.value ?: 0
+
+                    val floorCounts = records
+                        .filter { it.floor > 0 }
+                        .groupingBy { it.floor }
+                        .eachCount()
+
+                    val favouriteEntry       = floorCounts.maxByOrNull { it.value }
+                    val favouriteFloor       = favouriteEntry?.key ?: 0
+                    val favouriteFloorVisits = favouriteEntry?.value ?: 0
+
+                    val durationsByDay = records
+                        .mapNotNull { record ->
+                            record.timestamp?.toDate()?.let { date ->
+                                val cal = Calendar.getInstance(bogota)
+                                cal.time = date
+                                val dayName = when (cal.get(Calendar.DAY_OF_WEEK)) {
+                                    Calendar.MONDAY    -> "Monday"
+                                    Calendar.TUESDAY   -> "Tuesday"
+                                    Calendar.WEDNESDAY -> "Wednesday"
+                                    Calendar.THURSDAY  -> "Thursday"
+                                    Calendar.FRIDAY    -> "Friday"
+                                    Calendar.SATURDAY  -> "Saturday"
+                                    Calendar.SUNDAY    -> "Sunday"
+                                    else               -> null
+                                }
+                                dayName?.let { it to record.durationHours }
+                            }
+                        }
+                        .groupBy({ it.first }, { it.second })
+
+                    val avgDurationByDay = dayOrder
+                        .filter { durationsByDay.containsKey(it) }
+                        .associateWith { day ->
+                            val list = durationsByDay[day] ?: emptyList()
+                            if (list.isEmpty()) 0.0 else list.average()
+                        }
+
+                    Log.d("ParkingStatsVM", "[Default] Cálculo completado — $totalSessions sesiones")
+
+                    ComputedStats(
+                        totalSessions        = totalSessions,
+                        totalTimeHours       = totalTimeHours,
+                        totalPaidCOP         = totalPaidCOP,
+                        avgSessionHours      = avgSessionHours,
+                        busiestDay           = busiestDay,
+                        busiestDaySessions   = busiestDaySessions,
+                        favouriteFloor       = favouriteFloor,
+                        favouriteFloorVisits = favouriteFloorVisits,
+                        avgDurationByDay     = avgDurationByDay
+                    )
+                }
+
+                val stats = statsDeferred.await()
+                val now = System.currentTimeMillis()
+
+                // ── PASO 5: Persistir en las 3 capas de storage (IO) ──────────
+                async(Dispatchers.IO) {
+                    Log.d("ParkingStatsVM", "[IO] Persistiendo en Room + DataStore + archivo")
+
+                    // 1. Room — BD relacional
+                    val entity = ParkingStatsEntity(
+                        ownerEmail           = userEmail,
+                        totalSessions        = stats.totalSessions,
+                        totalTimeHours       = stats.totalTimeHours,
+                        totalPaidCOP         = stats.totalPaidCOP,
+                        avgSessionHours      = stats.avgSessionHours,
+                        busiestDay           = stats.busiestDay,
+                        busiestDaySessions   = stats.busiestDaySessions,
+                        favouriteFloor       = stats.favouriteFloor,
+                        favouriteFloorVisits = stats.favouriteFloorVisits,
+                        avgDurationByDay     = stats.avgDurationByDay,
+                        cachedAt             = now
+                    )
+                    dao.insertOrReplace(entity)
+                    Log.d("ParkingStatsVM", "[IO] Room actualizado")
+
+                    // 2. DataStore — metadata del caché
+                    dataStore.saveLastSyncTimestamp(now)
+                    dataStore.saveCachedUserEmail(userEmail)
+                    Log.d("ParkingStatsVM", "[IO] DataStore actualizado — timestamp: $now")
+
+                    // 3. Archivo local JSON — respaldo offline
+                    writeStatsToFile(stats, userEmail, now)
+                    Log.d("ParkingStatsVM", "[IO] Archivo JSON actualizado: ${statsFile.absolutePath}")
+
+                }.await()
+
+                // ── PASO 6: Actualizar UI en Main ─────────────────────────────
+                withContext(Dispatchers.Main) {
+                    Log.d("ParkingStatsVM", "[Main] Actualizando UI con stats frescos de Firestore")
+                    _uiState.value = ParkingStatsUIState(
+                        isLoading            = false,
+                        isRefreshing         = false,
+                        totalSessions        = stats.totalSessions,
+                        totalTimeHours       = stats.totalTimeHours,
+                        totalPaidCOP         = stats.totalPaidCOP,
+                        avgSessionHours      = stats.avgSessionHours,
+                        busiestDay           = stats.busiestDay,
+                        busiestDaySessions   = stats.busiestDaySessions,
+                        favouriteFloor       = stats.favouriteFloor,
+                        favouriteFloorVisits = stats.favouriteFloorVisits,
+                        avgDurationByDay     = stats.avgDurationByDay,
+                        lastSyncTimestamp    = now
+                    )
+                }
+
+            } catch (e: Exception) {
+                Log.e("ParkingStatsVM", "[Main] Error consultando Firestore: ${e.message}", e)
+
+                // Si Firestore falla pero tenemos caché, no mostramos error
+                if (cachedEntity != null) {
+                    Log.d("ParkingStatsVM", "[Main] Firestore falló — manteniendo datos de Room")
+                    withContext(Dispatchers.Main) {
+                        _uiState.value = cachedEntity.toUIState(isRefreshing = false)
+                    }
+                } else {
+                    // Sin caché y sin red — intentar leer archivo JSON
+                    val fileStats = readStatsFromFile(userEmail)
+                    withContext(Dispatchers.Main) {
+                        if (fileStats != null) {
+                            Log.d("ParkingStatsVM", "[Main] Mostrando datos desde archivo JSON")
+                            _uiState.value = fileStats
+                        } else {
+                            _uiState.value = _uiState.value.copy(
+                                isLoading    = false,
+                                isRefreshing = false,
+                                error        = e.message
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Escribir stats a archivo JSON local ───────────────────────────────────
+    // Dispatchers.IO — operación de disco
+    private fun writeStatsToFile(stats: ComputedStats, email: String, timestamp: Long) {
+        try {
+            val json = JSONObject().apply {
+                put("ownerEmail", email)
+                put("cachedAt", timestamp)
+                put("totalSessions", stats.totalSessions)
+                put("totalTimeHours", stats.totalTimeHours)
+                put("totalPaidCOP", stats.totalPaidCOP)
+                put("avgSessionHours", stats.avgSessionHours)
+                put("busiestDay", stats.busiestDay)
+                put("busiestDaySessions", stats.busiestDaySessions)
+                put("favouriteFloor", stats.favouriteFloor)
+                put("favouriteFloorVisits", stats.favouriteFloorVisits)
+                val dayMap = JSONObject()
+                stats.avgDurationByDay.forEach { (day, hours) -> dayMap.put(day, hours) }
+                put("avgDurationByDay", dayMap)
+            }
+            statsFile.writeText(json.toString())
+        } catch (e: Exception) {
+            Log.e("ParkingStatsVM", "[IO] Error escribiendo archivo JSON", e)
+        }
+    }
+
+    // ── Leer stats desde archivo JSON local ───────────────────────────────────
+    // Último recurso: sin Room y sin Firestore
+    private fun readStatsFromFile(userEmail: String): ParkingStatsUIState? {
+        return try {
+            if (!statsFile.exists()) return null
+            val json = JSONObject(statsFile.readText())
+            if (json.getString("ownerEmail") != userEmail) return null
+
+            val dayMapJson = json.getJSONObject("avgDurationByDay")
+            val avgDurationByDay = dayOrder
+                .filter { dayMapJson.has(it) }
+                .associateWith { dayMapJson.getDouble(it) }
+
+            ParkingStatsUIState(
+                isLoading            = false,
+                totalSessions        = json.getInt("totalSessions"),
+                totalTimeHours       = json.getDouble("totalTimeHours"),
+                totalPaidCOP         = json.getDouble("totalPaidCOP"),
+                avgSessionHours      = json.getDouble("avgSessionHours"),
+                busiestDay           = json.getString("busiestDay"),
+                busiestDaySessions   = json.getInt("busiestDaySessions"),
+                favouriteFloor       = json.getInt("favouriteFloor"),
+                favouriteFloorVisits = json.getInt("favouriteFloorVisits"),
+                avgDurationByDay     = avgDurationByDay,
+                lastSyncTimestamp    = json.getLong("cachedAt")
+            )
+        } catch (e: Exception) {
+            Log.e("ParkingStatsVM", "[IO] Error leyendo archivo JSON", e)
+            null
+        }
+    }
+
+    // ── Helpers de formato ────────────────────────────────────────────────────
+
+    fun formatTotalTime(hours: Double): String {
+        val h = hours.toInt()
+        val m = ((hours - h) * 60).toInt()
+        return when {
+            h > 0 && m > 0 -> "${h}h ${m}m"
+            h > 0           -> "${h}h"
+            else            -> "${m}m"
+        }
+    }
+
+    fun formatCOP(amount: Double): String {
+        return when {
+            amount >= 1_000_000 -> "$${(amount / 1_000_000).let { if (it % 1 == 0.0) it.toInt().toString() else String.format("%.1f", it) }}M"
+            amount >= 1_000     -> "$${(amount / 1_000).let { if (it % 1 == 0.0) it.toInt().toString() else String.format("%.1f", it) }}K"
+            else                -> "$${amount.toInt()}"
+        }
+    }
+
+    fun formatAvgDuration(hours: Double): String {
+        val h = hours.toInt()
+        val m = ((hours - h) * 60).toInt()
+        return when {
+            h > 0 && m > 0 -> "${h}h ${m}m"
+            h > 0           -> "${h}h"
+            else            -> "${m}m"
+        }
+    }
+
+    fun shortDay(day: String): String = day.take(3)
+
+    fun maxAvgDuration(map: Map<String, Double>): Double =
+        map.values.maxOrNull()?.takeIf { it > 0 } ?: 1.0
+}
+
+// ── Extension: ParkingStatsEntity → ParkingStatsUIState ──────────────────────
+// Convierte la entidad de Room al estado de UI sin pasar por el ViewModel.
+// Decisión: extension function en lugar de método en la entidad para respetar
+// la separación entre capa de datos y capa de UI del patrón MVVM.
+private fun ParkingStatsEntity.toUIState(isRefreshing: Boolean = false) = ParkingStatsUIState(
+    isLoading            = false,
+    isRefreshing         = isRefreshing,
+    totalSessions        = totalSessions,
+    totalTimeHours       = totalTimeHours,
+    totalPaidCOP         = totalPaidCOP,
+    avgSessionHours      = avgSessionHours,
+    busiestDay           = busiestDay,
+    busiestDaySessions   = busiestDaySessions,
+    favouriteFloor       = favouriteFloor,
+    favouriteFloorVisits = favouriteFloorVisits,
+    avgDurationByDay     = avgDurationByDay,
+    lastSyncTimestamp    = cachedAt
+)


### PR DESCRIPTION
## Summary
Implements a new ParkingStats screen accessible from the Profile screen, 
along with Multithreading and Local Storage strategies applied to the 
data loading and caching flow.

---

## New Screen — ParkingStats
- New `ParkingStatsScreen` accessible via Profile → "My Parking Stats" button
- Displays 3 KPI cards: Total Sessions, Total Time, Total Paid (COP)
- Average Session card with large time format
- Insight cards: Busiest Day (with session count) and Favourite Floor (with visit count)
- Bar chart showing average parking duration by day of the week
- Empty state, loading state and error state handled

---

## Multithreading Strategy
Implemented in `ParkingStatsViewModel` using 3 nested coroutines:

- **Coroutine 1 — Main**: orchestrator, updates UI state at start and end
- **Coroutine 2 — Dispatchers.IO**: fetches and parses records from Firestore (network/disk operations)
- **Coroutine 3 — Dispatchers.Default**: computes all stats (sumOf, groupBy, average, maxByOrNull — CPU-intensive)
- `viewModelScope` ensures automatic cancellation when ViewModel is destroyed
- `async/await` used instead of `launch` to pass results between coroutines
- `withContext(Dispatchers.Main)` explicit when updating StateFlow

---

## Local Storage Strategy
Four storage mechanisms implemented:

- **Room (Relational DB)**: persists computed stats in a local `parking_stats` table. Loads instantly on next open while Firestore refreshes in background
- **DataStore (Key-Value)**: stores cache metadata — `lastSyncTimestamp` and `cachedUserEmail`. Cache TTL set to 1 hour
- **Local JSON File**: written to internal storage as offline fallback. Used when both Room and Firestore are unavailable
- **Stale-while-revalidate flow**: Room → UI instantly, Firestore → Room → UI on refresh

---

## Files Added
- `ParkingStatsScreen.kt`
- `ParkingStatsViewModel.kt`
- `ParkingStatsEntity.kt`
- `ParkingStatsDao.kt`
- `ParkingStatsDatabase.kt`
- `ParkingStatsDataStore.kt`

## Files Modified
- `NavGraph.kt` — added `PARKING_STATS` route
- `ProfileScreen.kt` — added "My Parking Stats" navigation button
- `app/build.gradle.kts` — added Room dependencies