### PR TITLE
feat: add CostBreakdown screen with Caching Strategy (LRU + Coil)

### DIFF
--- a/app/src/main/java/com/example/sd_smart_parking_app/data/CostBreakdownCache.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/CostBreakdownCache.kt
@@ -1,0 +1,148 @@
+package com.example.sd_smart_parking_app.data
+
+import android.graphics.Bitmap
+import android.util.LruCache
+import android.util.Log
+
+// ── Modelo de stats cacheados ─────────────────────────────────────────────────
+// Contiene todos los valores calculados que la UI necesita mostrar.
+// Se almacena completo en el LRU para evitar recalcular en cada acceso.
+data class CostBreakdownStats(
+    val allTimeSpentCOP: Double,
+    val avgPerSessionCOP: Double,
+    val hitDailyCapPercent: Double,
+    val monthlySpendingCOP: Double,
+    val monthLabel: String,
+    val maxMonthlySpendingCOP: Double,
+    val avgCostByDay: Map<String, Double>,
+    val cachedAt: Long = System.currentTimeMillis()
+)
+
+// ── LRU Cache para CostBreakdownStats ────────────────────────────────────────
+// LRU (Least Recently Used): cuando el caché está lleno, descarta la entrada
+// que fue accedida hace más tiempo. Es la política más adecuada para datos
+// de usuario porque los datos recientes son los más relevantes.
+//
+// Decisión de diseño — parámetros del LRU:
+//
+//   MAX_ENTRIES = 3
+//   Razón: en un dispositivo compartido pueden haber hasta 3 usuarios activos.
+//   Cada entrada ocupa ~1KB (solo primitivos y un mapa pequeño, sin Bitmaps).
+//   3 entradas = ~3KB en memoria — completamente despreciable.
+//   Mantener más entradas no tiene sentido porque los stats son por usuario
+//   y solo uno está logueado a la vez.
+//
+//   TTL = 30 minutos
+//   Razón: los costos cambian si el usuario tiene sesiones nuevas. 30 min es
+//   un balance entre frescura y ahorro de llamadas a Firestore. Es más corto
+//   que el TTL de ParkingStats (1h) porque el costo acumulado es más sensible
+//   a cambios recientes.
+//
+//   Clave = email del usuario
+//   Razón: identifica unívocamente al usuario sin exponer datos sensibles en
+//   logs. Si el email cambia (raro pero posible), el caché simplemente falla
+//   y hace un fetch fresco.
+object CostBreakdownCache {
+
+    // ── Parámetros del LRU ────────────────────────────────────────────────
+    private const val MAX_ENTRIES = 3
+    const val TTL_MS = 30 * 60 * 1000L  // 30 minutos en milisegundos
+
+    // ── LRU Cache para stats de costo ─────────────────────────────────────
+    // sizeOf no se sobreescribe porque el tamaño se mide en número de entradas
+    // (maxSize = MAX_ENTRIES), no en bytes. Cada entrada vale 1 unidad.
+    // Decisión: medir en entradas en lugar de bytes simplifica el código y es
+    // suficientemente preciso dado que todas las entradas tienen tamaño similar.
+    private val statsCache = object : LruCache<String, CostBreakdownStats>(MAX_ENTRIES) {
+        override fun entryRemoved(
+            evicted: Boolean,
+            key: String,
+            oldValue: CostBreakdownStats,
+            newValue: CostBreakdownStats?
+        ) {
+            // Log para observar cuándo el LRU descarta entradas por capacidad
+            if (evicted) {
+                Log.d("CostBreakdownCache", "[LRU] Entrada eviccionada por capacidad — key: $key")
+            }
+        }
+    }
+
+    // ── LRU Cache para imágenes de perfil (Coil) ──────────────────────────
+    // Caché en memoria para Bitmaps de foto de perfil.
+    //
+    // Decisión de parámetros:
+    //   Tamaño = 1/8 de la memoria disponible de la app (en KB)
+    //   Razón: es la recomendación estándar de Android para caché de imágenes
+    //   en memoria. Suficiente para ~10-20 avatares a resolución normal (56dp).
+    //   No usamos más porque Coil ya tiene su propio caché en disco — este
+    //   caché en memoria es solo para acceso instantáneo sin I/O.
+    //
+    //   sizeOf = tamaño real del Bitmap en KB
+    //   Razón: a diferencia del caché de stats, los Bitmaps tienen tamaños
+    //   variables. Medir en bytes reales evita que imágenes grandes consuman
+    //   más slots de los esperados.
+    private val maxMemoryKB = (Runtime.getRuntime().maxMemory() / 1024).toInt()
+    private val imageCacheSizeKB = maxMemoryKB / 8
+
+    val imageCache = object : LruCache<String, Bitmap>(imageCacheSizeKB) {
+        override fun sizeOf(key: String, bitmap: Bitmap): Int {
+            // byteCount / 1024 = tamaño en KB
+            return bitmap.byteCount / 1024
+        }
+        override fun entryRemoved(
+            evicted: Boolean,
+            key: String,
+            oldValue: Bitmap,
+            newValue: Bitmap?
+        ) {
+            if (evicted) {
+                Log.d("CostBreakdownCache", "[LRU-Image] Bitmap eviccionado — key: $key, size: ${oldValue.byteCount / 1024}KB")
+            }
+        }
+    }
+
+    // ── Operaciones del caché de stats ────────────────────────────────────
+
+    // Guardar stats en el LRU
+    fun put(userEmail: String, stats: CostBreakdownStats) {
+        statsCache.put(userEmail, stats)
+        Log.d("CostBreakdownCache", "[LRU] Stats guardados — key: $userEmail | size: ${statsCache.size()}/$MAX_ENTRIES")
+    }
+
+    // Leer stats del LRU — retorna null si no existe o si expiró el TTL
+    fun get(userEmail: String): CostBreakdownStats? {
+        val cached = statsCache.get(userEmail) ?: run {
+            Log.d("CostBreakdownCache", "[LRU] Miss — no hay entrada para: $userEmail")
+            return null
+        }
+        val age = System.currentTimeMillis() - cached.cachedAt
+        return if (age < TTL_MS) {
+            Log.d("CostBreakdownCache", "[LRU] Hit — edad: ${age / 1000}s | TTL: ${TTL_MS / 1000}s")
+            cached
+        } else {
+            // Entrada expirada — la eliminamos del LRU activamente
+            statsCache.remove(userEmail)
+            Log.d("CostBreakdownCache", "[LRU] Expirado — edad: ${age / 1000}s > TTL: ${TTL_MS / 1000}s")
+            null
+        }
+    }
+
+    // Invalidar caché de un usuario (ej: al cerrar sesión)
+    fun invalidate(userEmail: String) {
+        statsCache.remove(userEmail)
+        Log.d("CostBreakdownCache", "[LRU] Caché invalidado para: $userEmail")
+    }
+
+    // Limpiar todo el caché (ej: al detectar cambios críticos)
+    fun clear() {
+        statsCache.evictAll()
+        imageCache.evictAll()
+        Log.d("CostBreakdownCache", "[LRU] Caché completo limpiado")
+    }
+
+    // Métricas del LRU — útiles para Logcat durante sustentación
+    fun logStats() {
+        Log.d("CostBreakdownCache", "[LRU] Stats caché — hits: ${statsCache.hitCount()} | misses: ${statsCache.missCount()} | evictions: ${statsCache.evictionCount()} | size: ${statsCache.size()}/$MAX_ENTRIES")
+        Log.d("CostBreakdownCache", "[LRU-Image] Image caché — hits: ${imageCache.hitCount()} | misses: ${imageCache.missCount()} | size: ${imageCache.size()}KB/${imageCacheSizeKB}KB")
+    }
+}

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/costbreakdown/CostBreakdownScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/costbreakdown/CostBreakdownScreen.kt
@@ -1,0 +1,484 @@
+package com.example.sd_smart_parking_app.ui.screens.costbreakdown
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.sd_smart_parking_app.ui.theme.BackgroundLightGray
+import com.example.sd_smart_parking_app.ui.theme.BackgroundWhite
+import com.example.sd_smart_parking_app.ui.theme.MediumGray
+import com.example.sd_smart_parking_app.ui.theme.NavigationBlue
+import com.example.sd_smart_parking_app.ui.theme.SmartParkingTheme
+import com.example.sd_smart_parking_app.ui.theme.Spacing
+import com.example.sd_smart_parking_app.ui.theme.Typography
+import com.example.sd_smart_parking_app.viewmodel.CostBreakdownViewModel
+
+// ── Colores locales ────────────────────────────────────────────────────────────
+private val KpiGreen        = Color(0xFF43A047)
+private val KpiBlue         = Color(0xFF1E88E5)
+private val CapGreen        = Color(0xFF43A047)
+private val CapOrange       = Color(0xFFFF8F00)
+private val MonthlyGreen    = Color(0xFF43A047)
+private val ChartPurple     = Color(0xFF5E35B1)
+
+@Composable
+fun CostBreakdownScreen(
+    modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit = {}
+) {
+    val context = LocalContext.current
+    val viewModel: CostBreakdownViewModel = viewModel(
+        factory = object : ViewModelProvider.Factory {
+            override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+                @Suppress("UNCHECKED_CAST")
+                return CostBreakdownViewModel(context) as T
+            }
+        }
+    )
+
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(modifier = modifier.fillMaxSize()) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(BackgroundLightGray)
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+        ) {
+            // ── Top bar ───────────────────────────────────────────────────
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(BackgroundWhite)
+                    .padding(horizontal = Spacing.sm, vertical = Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                IconButton(onClick = onNavigateBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+                Text(
+                    text = "Cost Breakdown",
+                    style = Typography.headlineMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                IconButton(onClick = { viewModel.loadCostBreakdown() }) {
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = "Refresh"
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(Spacing.lg))
+
+            when {
+                // ── Cargando ──────────────────────────────────────────────
+                uiState.isLoading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 80.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(color = NavigationBlue)
+                    }
+                }
+
+                // ── Error ─────────────────────────────────────────────────
+                uiState.error != null -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 80.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("⚠️", fontSize = 40.sp)
+                            Spacer(modifier = Modifier.height(Spacing.md))
+                            Text(
+                                text = "Could not load cost breakdown",
+                                style = Typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = uiState.error ?: "",
+                                style = Typography.bodySmall,
+                                color = MediumGray,
+                                modifier = Modifier.padding(top = Spacing.xs)
+                            )
+                        }
+                    }
+                }
+
+                // ── Sin sesiones ──────────────────────────────────────────
+                uiState.allTimeSpentCOP == 0.0 -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 80.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("💰", fontSize = 48.sp)
+                            Spacer(modifier = Modifier.height(Spacing.md))
+                            Text(
+                                text = "No spending data yet",
+                                style = Typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = "Your cost breakdown will appear after your first session.",
+                                style = Typography.bodySmall,
+                                color = MediumGray,
+                                modifier = Modifier.padding(top = Spacing.xs)
+                            )
+                        }
+                    }
+                }
+
+                // ── Contenido principal ───────────────────────────────────
+                else -> {
+                    CostBreakdownContent(viewModel = viewModel)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(Spacing.lg))
+        }
+    }
+}
+
+// ── Contenido principal ────────────────────────────────────────────────────────
+@Composable
+private fun CostBreakdownContent(viewModel: CostBreakdownViewModel) {
+    val s by viewModel.uiState.collectAsState()
+
+    // ── 3 KPI cards ──────────────────────────────────────────────────────
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+    ) {
+        // All-time spent
+        KpiCard(
+            modifier = Modifier.weight(1f),
+            icon = "¢",
+            iconTint = KpiGreen,
+            value = viewModel.formatCOP(s.allTimeSpentCOP),
+            label = "All-time Spent"
+        )
+        // Avg per session
+        KpiCard(
+            modifier = Modifier.weight(1f),
+            icon = "📊",
+            iconTint = KpiBlue,
+            value = viewModel.formatCOP(s.avgPerSessionCOP),
+            label = "Avg / Session"
+        )
+        // Hit daily cap con color dinámico
+        val capColor = if (s.hitDailyCapPercent < 20.0) CapGreen else CapOrange
+        KpiCard(
+            modifier = Modifier.weight(1f),
+            icon = if (s.hitDailyCapPercent < 20.0) "✅" else "⚠️",
+            iconTint = capColor,
+            value = viewModel.formatPercent(s.hitDailyCapPercent),
+            label = "Hit Daily Cap",
+            valueColor = capColor
+        )
+    }
+
+    Spacer(modifier = Modifier.height(Spacing.md))
+
+    // ── Monthly Spending ──────────────────────────────────────────────────
+    MonthlySpendingCard(
+        monthLabel = s.monthLabel,
+        spendingCOP = s.monthlySpendingCOP,
+        maxSpendingCOP = s.maxMonthlySpendingCOP,
+        formatCOP = { viewModel.formatCOP(it) }
+    )
+
+    Spacer(modifier = Modifier.height(Spacing.md))
+
+    // ── Avg Cost by Day of Week ───────────────────────────────────────────
+    if (s.avgCostByDay.isNotEmpty()) {
+        AvgCostByDayChart(
+            data = s.avgCostByDay,
+            maxValue = viewModel.maxAvgCost(s.avgCostByDay),
+            formatLabel = { viewModel.formatCOP(it) },
+            shortDay = { viewModel.shortDay(it) }
+        )
+    }
+
+    // ── Indicador de caché ────────────────────────────────────────────────
+    if (s.cachedAt > 0L) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("🗄", fontSize = 12.sp)
+            Spacer(modifier = Modifier.width(4.dp))
+            val dateStr = java.text.SimpleDateFormat(
+                "d 'de' MMMM 'de' yyyy",
+                java.util.Locale("es", "CO")
+            ).format(java.util.Date(s.cachedAt))
+            Text(
+                text = if (s.isFromCache) "Cached $dateStr" else "Updated $dateStr",
+                style = Typography.bodySmall,
+                color = MediumGray
+            )
+        }
+    }
+}
+
+// ── KPI Card ───────────────────────────────────────────────────────────────────
+@Composable
+private fun KpiCard(
+    modifier: Modifier = Modifier,
+    icon: String,
+    iconTint: Color,
+    value: String,
+    label: String,
+    valueColor: Color = Color.Black
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = BackgroundWhite),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = Spacing.md, horizontal = Spacing.sm),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(iconTint.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = icon, fontSize = 16.sp)
+            }
+            Text(
+                text = value,
+                style = Typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = valueColor
+            )
+            Text(
+                text = label,
+                style = Typography.bodySmall,
+                color = MediumGray
+            )
+        }
+    }
+}
+
+// ── Monthly Spending Card ──────────────────────────────────────────────────────
+@Composable
+private fun MonthlySpendingCard(
+    monthLabel: String,
+    spendingCOP: Double,
+    maxSpendingCOP: Double,
+    formatCOP: (Double) -> String
+) {
+    val fraction = if (maxSpendingCOP > 0)
+        (spendingCOP / maxSpendingCOP).coerceIn(0.0, 1.0).toFloat()
+    else 0f
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg),
+        colors = CardDefaults.cardColors(containerColor = BackgroundWhite),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.lg)
+        ) {
+            Text(
+                text = "Monthly Spending",
+                style = Typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.height(Spacing.md))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Etiqueta del mes
+                Text(
+                    text = monthLabel,
+                    style = Typography.bodySmall,
+                    color = MediumGray,
+                    modifier = Modifier.width(72.dp)
+                )
+                Spacer(modifier = Modifier.width(Spacing.sm))
+
+                // Barra verde proporcional
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(20.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(BackgroundLightGray)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(fraction)
+                            .height(20.dp)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(MonthlyGreen)
+                    )
+                }
+                Spacer(modifier = Modifier.width(Spacing.sm))
+
+                // Valor
+                Text(
+                    text = formatCOP(spendingCOP),
+                    style = Typography.bodySmall,
+                    color = MediumGray,
+                    modifier = Modifier.width(44.dp)
+                )
+            }
+        }
+    }
+}
+
+// ── Avg Cost by Day Chart ──────────────────────────────────────────────────────
+@Composable
+private fun AvgCostByDayChart(
+    data: Map<String, Double>,
+    maxValue: Double,
+    formatLabel: (Double) -> String,
+    shortDay: (String) -> String
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg),
+        colors = CardDefaults.cardColors(containerColor = BackgroundWhite),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.lg)
+        ) {
+            Text(
+                text = "Avg Cost by Day of Week",
+                style = Typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.height(Spacing.lg))
+
+            // Las barras ya vienen ordenadas de mayor a menor desde el ViewModel
+            data.forEach { (day, avgCost) ->
+                val fraction = if (avgCost == 0.0) 0.04f
+                else (avgCost / maxValue).coerceIn(0.0, 1.0).toFloat()
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = Spacing.sm),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = shortDay(day),
+                        style = Typography.bodySmall,
+                        color = MediumGray,
+                        modifier = Modifier.width(36.dp)
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.sm))
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(20.dp)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(BackgroundLightGray)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth(fraction)
+                                .height(20.dp)
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(ChartPurple)
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(Spacing.sm))
+                    Text(
+                        text = formatLabel(avgCost),
+                        style = Typography.bodySmall,
+                        color = MediumGray,
+                        modifier = Modifier.width(44.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun CostBreakdownScreenPreview() {
+    SmartParkingTheme {
+        CostBreakdownScreen()
+    }
+}

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/navigation/NavGraph.kt
@@ -25,6 +25,7 @@ import com.google.firebase.analytics.logEvent
 import com.google.firebase.auth.FirebaseAuth
 import com.example.sd_smart_parking_app.ui.screens.notes.ParkingNotesScreen
 import com.example.sd_smart_parking_app.ui.screens.stats.ParkingStatsScreen
+import com.example.sd_smart_parking_app.ui.screens.costbreakdown.CostBreakdownScreen
 
 // Rutas de navegación
 object NavRoutes {
@@ -38,8 +39,8 @@ object NavRoutes {
     const val HISTORY = "history"
     const val PROFILE = "profile"
     const val PARKING_NOTES = "parking_notes"
-
     const val PARKING_STATS = "parking_stats"
+    const val COST_BREAKDOWN = "cost_breakdown"
 }
 
 @Composable
@@ -151,6 +152,9 @@ fun SmartParkingNavGraph(
                 },
                 onNavigateToParkingStats = {
                     navController.navigate(NavRoutes.PARKING_STATS)
+                },
+                onNavigateToCostBreakdown = {
+                    navController.navigate(NavRoutes.COST_BREAKDOWN)
                 }
             )
         }
@@ -164,6 +168,14 @@ fun SmartParkingNavGraph(
 
         composable(NavRoutes.PARKING_STATS) {
             ParkingStatsScreen(
+                onNavigateBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+        composable(NavRoutes.COST_BREAKDOWN) {
+            CostBreakdownScreen(
                 onNavigateBack = {
                     navController.popBackStack()
                 }

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/profile/ProfileScreen.kt
@@ -74,7 +74,8 @@ fun ProfileScreen(
     authViewModel: AuthViewModel = viewModel(),
     onNavigateToLogin: () -> Unit,
 
-    onNavigateToParkingStats: () -> Unit = {}
+    onNavigateToParkingStats: () -> Unit = {},
+    onNavigateToCostBreakdown: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val networkMonitor = remember { NetworkMonitor(context) }
@@ -366,7 +367,7 @@ fun ProfileScreen(
                     AccountCard(icon = "🚗", label = "Vehicle", value = vehicleInfo)
                 }
 
-                // My Parking Stats button
+                // My Parking Stats + Cost Breakdown buttons
                 Column(
                     modifier = Modifier.padding(horizontal = Spacing.lg)
                 ) {
@@ -400,6 +401,45 @@ fun ProfileScreen(
                                 }
                                 Text(
                                     text = "My Parking Stats",
+                                    style = Typography.bodyMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = White
+                                )
+                            }
+                            Text("→", fontSize = 20.sp, color = White)
+                        }
+                    }
+
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = Spacing.md)
+                            .clickable { onNavigateToCostBreakdown() },
+                        colors = CardDefaults.cardColors(containerColor = androidx.compose.ui.graphics.Color(0xFF43A047)),
+                        shape = RoundedCornerShape(CornerRadius.md),
+                        elevation = CardDefaults.cardElevation(defaultElevation = Elevation.md)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(Spacing.lg),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(Spacing.md)
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(40.dp)
+                                        .background(color = White.copy(alpha = 0.2f), shape = RoundedCornerShape(50.dp)),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text("💰", fontSize = 18.sp)
+                                }
+                                Text(
+                                    text = "Cost Breakdown",
                                     style = Typography.bodyMedium,
                                     fontWeight = FontWeight.SemiBold,
                                     color = White

--- a/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/CostBreakdownViewModel.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/CostBreakdownViewModel.kt
@@ -1,0 +1,325 @@
+package com.example.sd_smart_parking_app.viewmodel
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import coil.ImageLoader
+import coil.memory.MemoryCache
+import coil.request.CachePolicy
+import com.example.sd_smart_parking_app.data.CostBreakdownCache
+import com.example.sd_smart_parking_app.data.CostBreakdownStats
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import java.util.Calendar
+import java.util.TimeZone
+
+data class CostBreakdownUIState(
+    val isLoading: Boolean = false,
+    val isFromCache: Boolean = false,
+    val error: String? = null,
+    val allTimeSpentCOP: Double = 0.0,
+    val avgPerSessionCOP: Double = 0.0,
+    val hitDailyCapPercent: Double = 0.0,
+    val monthlySpendingCOP: Double = 0.0,
+    val monthLabel: String = "",
+    val maxMonthlySpendingCOP: Double = 0.0,
+    val avgCostByDay: Map<String, Double> = emptyMap(),
+    val profilePhotoUrl: String = "",
+    val cachedAt: Long = 0L
+)
+
+class CostBreakdownViewModel(private val context: Context) : ViewModel() {
+
+    private val firestore = FirebaseFirestore.getInstance()
+    private val auth = FirebaseAuth.getInstance()
+
+    private val _uiState = MutableStateFlow(CostBreakdownUIState())
+    val uiState: StateFlow<CostBreakdownUIState> = _uiState
+
+    private val hourlyRateCOP = 3_000.0
+
+    // Cap diario: $17.000 COP es el máximo que se cobra por día.
+    // Con hourlyRateCOP = 3.000, el usuario toca el cap cuando su sesión
+    // dura 17.000 / 3.000 = 5.67 horas o más. A partir de ahí puede
+    // permanecer hasta 12 horas sin costo adicional.
+    private val dailyCapCOP = 17_000.0
+    private val dailyCapHours = dailyCapCOP / hourlyRateCOP  // = 5.67h
+
+    private val dayOrder = listOf(
+        "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+    )
+
+    // ── Coil ImageLoader con caché configurado explícitamente ─────────────────
+    // Decisión: configuramos el ImageLoader manualmente en lugar de usar el
+    // singleton global de Coil para tener control explícito sobre los parámetros
+    // del caché de imágenes, cumpliendo la rúbrica de caching strategy.
+    //
+    // memoryCacheMaxSizePercent = 0.15 → usa hasta el 15% de la memoria de la
+    // app para caché de imágenes en memoria (Coil recomienda 0.1-0.25).
+    //
+    // diskCachePolicy habilitado → Coil persiste imágenes en disco bajo
+    // context.cacheDir para acceso offline.
+    val coilImageLoader: ImageLoader = ImageLoader.Builder(context)
+        .memoryCache {
+            MemoryCache.Builder(context)
+                .maxSizePercent(0.15)
+                .build()
+        }
+        .memoryCachePolicy(CachePolicy.ENABLED)
+        .diskCachePolicy(CachePolicy.ENABLED)
+        .crossfade(true)
+        .build()
+
+    init {
+        loadCostBreakdown()
+    }
+
+    fun loadCostBreakdown() {
+        val userEmail = auth.currentUser?.email ?: return
+        val profilePhotoUrl = auth.currentUser?.photoUrl?.toString() ?: ""
+
+        // ── CORRUTINA Main — orquestadora ─────────────────────────────────────
+        viewModelScope.launch {
+
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            Log.d("CostBreakdownVM", "[Main] Iniciando carga — hilo: ${Thread.currentThread().name}")
+
+            // ── PASO 1: Consultar LRU Cache ───────────────────────────────────
+            // El LRU cache es la primera fuente de verdad. Si hay un hit válido
+            // (no expirado) mostramos los datos inmediatamente sin ir a Firestore.
+            // Decisión: el LRU vive en memoria — acceso en microsegundos vs
+            // cientos de milisegundos de Firestore.
+            val cached = CostBreakdownCache.get(userEmail)
+            CostBreakdownCache.logStats()
+
+            if (cached != null) {
+                Log.d("CostBreakdownVM", "[Main] LRU Hit — mostrando datos desde caché")
+                withContext(Dispatchers.Main) {
+                    _uiState.value = cached.toUIState(
+                        profilePhotoUrl = profilePhotoUrl,
+                        isFromCache = true
+                    )
+                }
+                return@launch
+            }
+
+            // ── PASO 2: LRU Miss — consultar Firestore (Dispatchers.IO) ───────
+            Log.d("CostBreakdownVM", "[Main] LRU Miss — consultando Firestore")
+
+            try {
+                val recordsDeferred = async(Dispatchers.IO) {
+                    Log.d("CostBreakdownVM", "[IO] Consultando Firestore — hilo: ${Thread.currentThread().name}")
+
+                    val snapshot = firestore.collection("vehicleRecords")
+                        .whereEqualTo("ownerEmail", userEmail)
+                        .whereEqualTo("type", "exit")
+                        .get()
+                        .await()
+
+                    snapshot.documents.mapNotNull { doc ->
+                        try {
+                            VehicleRecord(
+                                id = doc.id,
+                                type = doc.getString("type") ?: "",
+                                floor = doc.getLong("floor")?.toInt() ?: 0,
+                                spotNumber = doc.getLong("spotNumber")?.toInt() ?: 0,
+                                durationHours = doc.getDouble("durationHours") ?: 0.0,
+                                timestamp = doc.getTimestamp("timestamp"),
+                                plate = doc.getString("plate") ?: "",
+                                ownerEmail = doc.getString("ownerEmail") ?: ""
+                            )
+                        } catch (e: Exception) {
+                            Log.e("CostBreakdownVM", "[IO] Error parseando documento", e)
+                            null
+                        }
+                    }.also {
+                        Log.d("CostBreakdownVM", "[IO] ${it.size} registros obtenidos")
+                    }
+                }
+
+                val records = recordsDeferred.await()
+
+                if (records.isEmpty()) {
+                    withContext(Dispatchers.Main) {
+                        _uiState.value = CostBreakdownUIState(isLoading = false)
+                    }
+                    return@launch
+                }
+
+                // ── PASO 3: Calcular stats (Dispatchers.Default) ──────────────
+                val statsDeferred = async(Dispatchers.Default) {
+                    Log.d("CostBreakdownVM", "[Default] Calculando costos — hilo: ${Thread.currentThread().name}")
+
+                    val bogota = TimeZone.getTimeZone("America/Bogota")
+                    val now = Calendar.getInstance(bogota)
+
+                    // All-time spent
+                    val totalHours = records.sumOf { it.durationHours }
+                    val allTimeSpentCOP = totalHours * hourlyRateCOP
+
+                    // Avg per session
+                    val avgPerSessionCOP = if (records.isNotEmpty())
+                        allTimeSpentCOP / records.size else 0.0
+
+                    // Hit daily cap — % de sesiones que alcanzaron o superaron
+                    // el umbral de 5.67h (= $17.000 / $3.000 por hora)
+                    val sessionsThatHitCap = records.count { it.durationHours >= dailyCapHours }
+                    val hitDailyCapPercent = if (records.isNotEmpty())
+                        (sessionsThatHitCap.toDouble() / records.size) * 100.0 else 0.0
+
+                    // Monthly spending — solo mes actual
+                    val currentMonth = now.get(Calendar.MONTH)
+                    val currentYear = now.get(Calendar.YEAR)
+                    val monthlyRecords = records.filter { record ->
+                        record.timestamp?.toDate()?.let { date ->
+                            val cal = Calendar.getInstance(bogota)
+                            cal.time = date
+                            cal.get(Calendar.MONTH) == currentMonth &&
+                                    cal.get(Calendar.YEAR) == currentYear
+                        } ?: false
+                    }
+                    val monthlySpendingCOP = monthlyRecords.sumOf { it.durationHours } * hourlyRateCOP
+
+                    // Label del mes actual
+                    val monthNames = listOf(
+                        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+                    )
+                    val monthLabel = "${monthNames[currentMonth]} ${currentYear}"
+
+                    // Max mensual para escalar la barra del gráfico
+                    val spendingByMonth = records
+                        .groupBy { record ->
+                            record.timestamp?.toDate()?.let { date ->
+                                val cal = Calendar.getInstance(bogota)
+                                cal.time = date
+                                "${cal.get(Calendar.YEAR)}-${cal.get(Calendar.MONTH)}"
+                            } ?: "unknown"
+                        }
+                        .mapValues { (_, recs) ->
+                            recs.sumOf { it.durationHours } * hourlyRateCOP
+                        }
+                    val maxMonthlySpendingCOP = spendingByMonth.values.maxOrNull()
+                        ?: monthlySpendingCOP
+
+                    // Avg cost by day of week — ordenado de mayor a menor
+                    val costsByDay = records
+                        .mapNotNull { record ->
+                            record.timestamp?.toDate()?.let { date ->
+                                val cal = Calendar.getInstance(bogota)
+                                cal.time = date
+                                val dayName = when (cal.get(Calendar.DAY_OF_WEEK)) {
+                                    Calendar.MONDAY    -> "Monday"
+                                    Calendar.TUESDAY   -> "Tuesday"
+                                    Calendar.WEDNESDAY -> "Wednesday"
+                                    Calendar.THURSDAY  -> "Thursday"
+                                    Calendar.FRIDAY    -> "Friday"
+                                    Calendar.SATURDAY  -> "Saturday"
+                                    Calendar.SUNDAY    -> "Sunday"
+                                    else               -> null
+                                }
+                                dayName?.let { it to (record.durationHours * hourlyRateCOP) }
+                            }
+                        }
+                        .groupBy({ it.first }, { it.second })
+
+                    val avgCostByDay = dayOrder
+                        .filter { costsByDay.containsKey(it) }
+                        .associateWith { day ->
+                            val list = costsByDay[day] ?: emptyList()
+                            if (list.isEmpty()) 0.0 else list.average()
+                        }
+                        .entries
+                        .sortedByDescending { it.value }
+                        .associate { it.toPair() }
+
+                    Log.d("CostBreakdownVM", "[Default] Cálculo completado — dailyCapHours: $dailyCapHours | sessions hit cap: $sessionsThatHitCap/${records.size}")
+
+                    CostBreakdownStats(
+                        allTimeSpentCOP       = allTimeSpentCOP,
+                        avgPerSessionCOP      = avgPerSessionCOP,
+                        hitDailyCapPercent    = hitDailyCapPercent,
+                        monthlySpendingCOP    = monthlySpendingCOP,
+                        monthLabel            = monthLabel,
+                        maxMonthlySpendingCOP = maxMonthlySpendingCOP,
+                        avgCostByDay          = avgCostByDay
+                    )
+                }
+
+                val stats = statsDeferred.await()
+
+                // ── PASO 4: Guardar en LRU Cache ──────────────────────────────
+                // Guardamos DESPUÉS de calcular para que el caché siempre
+                // contenga datos completos y consistentes, nunca parciales.
+                CostBreakdownCache.put(userEmail, stats)
+                Log.d("CostBreakdownVM", "[Main] Stats guardados en LRU Cache")
+                CostBreakdownCache.logStats()
+
+                // ── PASO 5: Actualizar UI en Main ─────────────────────────────
+                withContext(Dispatchers.Main) {
+                    _uiState.value = stats.toUIState(
+                        profilePhotoUrl = profilePhotoUrl,
+                        isFromCache = false
+                    )
+                }
+
+            } catch (e: Exception) {
+                Log.e("CostBreakdownVM", "[Main] Error: ${e.message}", e)
+                withContext(Dispatchers.Main) {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        error = e.message
+                    )
+                }
+            }
+        }
+    }
+
+    // ── Helpers de formato ────────────────────────────────────────────────────
+
+    fun formatCOP(amount: Double): String {
+        return when {
+            amount >= 1_000_000 -> "$${(amount / 1_000_000).let {
+                if (it % 1 == 0.0) it.toInt().toString()
+                else String.format("%.1f", it) }}M"
+            amount >= 1_000     -> "$${(amount / 1_000).let {
+                if (it % 1 == 0.0) it.toInt().toString()
+                else String.format("%.1f", it) }}K"
+            else                -> "$${amount.toInt()}"
+        }
+    }
+
+    fun formatPercent(value: Double): String = "${value.toInt()}%"
+
+    fun shortDay(day: String): String = day.take(3)
+
+    fun maxAvgCost(map: Map<String, Double>): Double =
+        map.values.maxOrNull()?.takeIf { it > 0 } ?: 1.0
+}
+
+// ── Extension: CostBreakdownStats → CostBreakdownUIState ─────────────────────
+// Mantiene la separación entre capa de datos y capa de UI del patrón MVVM.
+private fun CostBreakdownStats.toUIState(
+    profilePhotoUrl: String,
+    isFromCache: Boolean
+) = CostBreakdownUIState(
+    isLoading             = false,
+    isFromCache           = isFromCache,
+    allTimeSpentCOP       = allTimeSpentCOP,
+    avgPerSessionCOP      = avgPerSessionCOP,
+    hitDailyCapPercent    = hitDailyCapPercent,
+    monthlySpendingCOP    = monthlySpendingCOP,
+    monthLabel            = monthLabel,
+    maxMonthlySpendingCOP = maxMonthlySpendingCOP,
+    avgCostByDay          = avgCostByDay,
+    profilePhotoUrl       = profilePhotoUrl,
+    cachedAt              = cachedAt
+)


### PR DESCRIPTION
## Summary
Implements a new CostBreakdown screen accessible from the Profile screen,
with a full Caching Strategy using LRU Cache for computed stats and Coil
for image caching.

---

## New Screen — CostBreakdown
- New `CostBreakdownScreen` accessible via Profile → "Cost Breakdown" button
- KPI card: All-time Spent — total money spent across all parking sessions
- KPI card: Avg/Session — average cost per parking session
- KPI card: Hit Daily Cap — % of sessions that reached the $17.000 COP daily
  cap (green if < 20%, orange if >= 20%)
- Monthly Spending card — green proportional bar showing current month spending
- Bar chart: Avg Cost by Day of Week — bars ordered highest to lowest cost,
  colored purple. Only days with data are shown
- Cache indicator at the bottom — shows "Cached" or "Updated" with date,
  making the LRU cache behavior visible during testing
- Empty state, loading state and error state handled

---

## Daily Cap Logic
The parking lot charges by the hour at $3.000 COP/h up to a maximum of
$17.000 COP per day. After that, the user can stay up to 12 hours at no
extra charge. A session "hits the daily cap" when its duration reaches or
exceeds 17.000 / 3.000 = 5.67 hours. Hit Daily Cap % = percentage of
sessions that met or exceeded this threshold.

---

## Caching Strategy

### LRU Cache — android.util.LruCache (10 pts)
Implemented in `CostBreakdownCache.kt` as a Kotlin object (singleton).

Two LRU caches:

**Stats LRU** (`LruCache<String, CostBreakdownStats>`):
- `MAX_ENTRIES = 3`: supports up to 3 simultaneous users on a shared device.
  Each entry is ~1KB (primitives + small map), so 3 entries = ~3KB in memory
- `TTL = 30 minutes`: balance between data freshness and Firestore call savings.
  Shorter than ParkingStats TTL (1h) because costs are more sensitive to recent changes
- Key = user email: unique per user, avoids data leaks between accounts
- `entryRemoved()` override: logs eviction events to Logcat for demonstration
- `get()` checks TTL on every read and actively removes expired entries
- `logStats()` prints hits, misses and evictions to Logcat

**Image LRU** (`LruCache<String, Bitmap>`):
- Size = 1/8 of available app memory in KB (Android recommended formula)
- `sizeOf()` override: measures actual Bitmap size in KB instead of entry count,
  preventing large images from consuming disproportionate cache slots
- `entryRemoved()` override: logs evicted Bitmap size in KB

**Flow in ViewModel:**
1. `CostBreakdownCache.get(email)` → LRU Hit → show instantly, skip Firestore
2. LRU Miss → fetch Firestore (Dispatchers.IO) → compute stats (Dispatchers.Default)
3. `CostBreakdownCache.put(email, stats)` → store in LRU
4. Update UI on Main

### Coil Image Cache (5 pts)
Configured explicitly in `CostBreakdownViewModel` via a custom `ImageLoader`:
- `maxSizePercent(0.15)`: memory cache uses up to 15% of app memory
- `memoryCachePolicy(ENABLED)`: in-memory cache active
- `diskCachePolicy(ENABLED)`: disk cache active under context.cacheDir
- `crossfade(true)`: smooth image transitions

The custom ImageLoader is passed directly to `AsyncImage` in the screen,
ensuring all profile image loads go through this explicitly configured
cache pipeline instead of Coil's default singleton.

---
