### PR TITLE
feat: add NearbyParking feature with Firestore sync, LruCache, Shared…

### DIFF
--- a/app/src/main/java/com/example/sd_smart_parking_app/data/model/NearbyParking.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/model/NearbyParking.kt
@@ -1,0 +1,12 @@
+package com.example.sd_smart_parking_app.data.model
+
+data class NearbyParking(
+    val id: String = "",
+    val name: String = "",
+    val address: String = "",
+    val lat: Double = 0.0,
+    val lng: Double = 0.0,
+    val approximateCapacity: Int = 0,
+    val phone: String = "",
+    val distanceMeters: Float = 0f
+)

--- a/app/src/main/java/com/example/sd_smart_parking_app/data/repository/NearbyParkingRepository.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/repository/NearbyParkingRepository.kt
@@ -1,0 +1,274 @@
+package com.example.sd_smart_parking_app.data.repository
+
+// Firestore collection: "nearbyParking"
+// Each document has:
+//   id: String (document ID, also stored as field)
+//   name: String
+//   address: String
+//   lat: Double
+//   lng: Double
+//   approximateCapacity: Int
+//   phone: String
+//
+// Sample documents to add manually in Firebase Console:
+// Document ID: parking_calle_19
+//   name: "Parqueadero Calle 19"
+//   address: "Cl. 19 #3-16, Bogotá"
+//   lat: 4.60098
+//   lng: -74.06521
+//   approximateCapacity: 80
+//   phone: "+57 1 234 5678"
+//
+// Document ID: parking_la_candelaria
+//   name: "Parqueadero La Candelaria"
+//   address: "Cr. 2 #12b-24, Bogotá"
+//   lat: 4.59843
+//   lng: -74.07102
+//   approximateCapacity: 45
+//   phone: "+57 1 345 6789"
+//
+// Document ID: parking_eje_ambiental
+//   name: "Parqueadero Eje Ambiental"
+//   address: "Av. Jiménez #3-50, Bogotá"
+//   lat: 4.60201
+//   lng: -74.06874
+//   approximateCapacity: 120
+//   phone: "+57 1 456 7890"
+
+import android.content.Context
+import android.util.Log
+import android.util.LruCache
+import com.example.sd_smart_parking_app.data.model.NearbyParking
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sealed result type
+// ─────────────────────────────────────────────────────────────────────────────
+sealed class NearbyParkingResult {
+    data class Fresh(val data: List<NearbyParking>) : NearbyParkingResult()
+    data class FromCache(val data: List<NearbyParking>, val savedAtMs: Long) : NearbyParkingResult()
+    data class FromLocalStorage(val data: List<NearbyParking>, val savedAtMs: Long) : NearbyParkingResult()
+    object NoData : NearbyParkingResult()
+}
+
+class NearbyParkingRepository private constructor(private val context: Context) {
+
+    private val firestore = FirebaseFirestore.getInstance()
+
+    // SD building reference coordinates
+    private val SD_LAT = 4.60145
+    private val SD_LNG = -74.06617
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // LruCache (in-memory cache)
+    // maxSize = 1 — only one list at a time
+    // Value: Pair(list, timestamp when cached)
+    // ─────────────────────────────────────────────────────────────────────────
+    private val nearbyParkingCache = LruCache<String, Pair<List<NearbyParking>, Long>>(1)
+    private val cacheTtlMs = 10 * 60 * 1000L  // 10 minutes
+    private val CACHE_KEY = "nearby_parking"
+
+    private fun isCacheValid(): Boolean {
+        val cached = nearbyParkingCache.get(CACHE_KEY) ?: return false
+        val isNotExpired = (System.currentTimeMillis() - cached.second) < cacheTtlMs
+        Log.d("NearbyParkingRepo", "isCacheValid=$isNotExpired — age=${System.currentTimeMillis() - cached.second}ms")
+        return isNotExpired
+    }
+
+    private fun getCached(): Pair<List<NearbyParking>, Long>? = nearbyParkingCache.get(CACHE_KEY)
+
+    private fun saveToCache(list: List<NearbyParking>) {
+        nearbyParkingCache.put(CACHE_KEY, Pair(list, System.currentTimeMillis()))
+        Log.d("NearbyParkingRepo", "LruCache updated — ${list.size} items stored")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SharedPreferences (local storage)
+    // ─────────────────────────────────────────────────────────────────────────
+    private val prefs by lazy {
+        context.getSharedPreferences("nearby_parking_prefs", Context.MODE_PRIVATE)
+    }
+
+    private fun saveToSharedPreferences(list: List<NearbyParking>) {
+        val array = JSONArray()
+        list.forEach { parking ->
+            val obj = JSONObject().apply {
+                put("id", parking.id)
+                put("name", parking.name)
+                put("address", parking.address)
+                put("lat", parking.lat)
+                put("lng", parking.lng)
+                put("approximateCapacity", parking.approximateCapacity)
+                put("phone", parking.phone)
+                // distanceMeters is NOT persisted — recalculated on load
+            }
+            array.put(obj)
+        }
+        prefs.edit()
+            .putString("nearby_parking_json", array.toString())
+            .putLong("nearby_parking_saved_at", System.currentTimeMillis())
+            .apply()
+        Log.d("NearbyParkingRepo", "SharedPreferences updated — ${list.size} items saved")
+    }
+
+    private fun loadFromSharedPreferences(): List<NearbyParking>? {
+        val json = prefs.getString("nearby_parking_json", null) ?: run {
+            Log.d("NearbyParkingRepo", "SharedPreferences — no data found")
+            return null
+        }
+        return try {
+            val array = JSONArray(json)
+            val list = (0 until array.length()).map { i ->
+                val obj = array.getJSONObject(i)
+                NearbyParking(
+                    id = obj.getString("id"),
+                    name = obj.getString("name"),
+                    address = obj.getString("address"),
+                    lat = obj.getDouble("lat"),
+                    lng = obj.getDouble("lng"),
+                    approximateCapacity = obj.getInt("approximateCapacity"),
+                    phone = obj.getString("phone")
+                    // distanceMeters left as default 0f — recalculated after loading
+                )
+            }
+            Log.d("NearbyParkingRepo", "SharedPreferences loaded — ${list.size} items")
+            list
+        } catch (e: Exception) {
+            Log.e("NearbyParkingRepo", "Error parsing SharedPreferences JSON: ${e.message}", e)
+            null
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Distance helpers
+    // ─────────────────────────────────────────────────────────────────────────
+    private fun withDistances(list: List<NearbyParking>): List<NearbyParking> {
+        return list.map { parking ->
+            val results = FloatArray(1)
+            android.location.Location.distanceBetween(SD_LAT, SD_LNG, parking.lat, parking.lng, results)
+            parking.copy(distanceMeters = results[0])
+        }.sortedBy { it.distanceMeters }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Main public function — "Network falling back to cache" strategy
+    // Priority: Firestore → LruCache → SharedPreferences → NoData
+    // ─────────────────────────────────────────────────────────────────────────
+    suspend fun getNearbyParking(): NearbyParkingResult {
+        // 1. Try Firestore fetch (multi-threaded with two parallel coroutines)
+        return try {
+            val freshList = withContext(Dispatchers.IO) {
+                fetchFromFirestoreWithParallelCoroutines()
+            }
+            saveToCache(freshList)
+            withContext(Dispatchers.IO) {
+                saveToSharedPreferences(freshList)
+            }
+            Log.d("NearbyParkingRepo", "Returning Fresh data — ${freshList.size} items")
+            NearbyParkingResult.Fresh(freshList)
+
+        } catch (e: Exception) {
+            Log.w("NearbyParkingRepo", "Firestore fetch failed: ${e.message} — falling back to cache")
+
+            // 2. Check LruCache
+            if (isCacheValid()) {
+                val (cachedList, timestamp) = getCached()!!
+                val listWithDistances = withDistances(cachedList)
+                Log.d("NearbyParkingRepo", "Cache hit — returning ${listWithDistances.size} items from LruCache")
+                return NearbyParkingResult.FromCache(listWithDistances, timestamp)
+            }
+            Log.d("NearbyParkingRepo", "Cache miss — checking SharedPreferences")
+
+            // 3. Check SharedPreferences
+            val localList = withContext(Dispatchers.IO) { loadFromSharedPreferences() }
+            if (!localList.isNullOrEmpty()) {
+                val savedAt = prefs.getLong("nearby_parking_saved_at", 0L)
+                val listWithDistances = withDistances(localList)
+                Log.d("NearbyParkingRepo", "SharedPreferences hit — returning ${listWithDistances.size} items")
+                return NearbyParkingResult.FromLocalStorage(listWithDistances, savedAt)
+            }
+            Log.d("NearbyParkingRepo", "No data available in any source")
+
+            // 4. NoData
+            NearbyParkingResult.NoData
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Multi-threading: two parallel coroutines inside coroutineScope
+    //   parkingJob  — Dispatchers.IO  — fetches documents from Firestore
+    //   distanceJob — Dispatchers.Default — CPU-bound distance computation
+    // ─────────────────────────────────────────────────────────────────────────
+    private suspend fun fetchFromFirestoreWithParallelCoroutines(): List<NearbyParking> =
+        coroutineScope {
+            val parkingJob = async(Dispatchers.IO) {
+                Log.d("NearbyParkingRepo", "Coroutine parkingJob running on: ${Thread.currentThread().name}")
+                firestore.collection("nearbyParking")
+                    .get()
+                    .await()
+                    .documents
+                    .mapNotNull { doc ->
+                        try {
+                            NearbyParking(
+                                id = doc.id,
+                                name = doc.getString("name") ?: "",
+                                address = doc.getString("address") ?: "",
+                                lat = doc.getDouble("lat") ?: 0.0,
+                                lng = doc.getDouble("lng") ?: 0.0,
+                                approximateCapacity = doc.getLong("approximateCapacity")?.toInt() ?: 0,
+                                phone = doc.getString("phone") ?: ""
+                            )
+                        } catch (e: Exception) {
+                            Log.e("NearbyParkingRepo", "Error parsing document ${doc.id}: ${e.message}", e)
+                            null
+                        }
+                    }
+            }
+
+            // distanceJob runs on Dispatchers.Default (CPU pool).
+            // It waits for parkingJob to finish, then performs the Haversine
+            // distance calculation — CPU-bound work on the computation dispatcher.
+            val distanceJob = async(Dispatchers.Default) {
+                Log.d("NearbyParkingRepo", "Coroutine distanceJob running on: ${Thread.currentThread().name}")
+                parkingJob.await().associate { parking ->
+                    val results = FloatArray(1)
+                    android.location.Location.distanceBetween(
+                        SD_LAT, SD_LNG,
+                        parking.lat, parking.lng,
+                        results
+                    )
+                    parking.id to results[0]
+                }
+            }
+
+            val parkingList = parkingJob.await()
+            val distances = distanceJob.await()
+
+            parkingList
+                .map { parking -> parking.copy(distanceMeters = distances[parking.id] ?: 0f) }
+                .sortedBy { it.distanceMeters }
+        }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Singleton
+    // ─────────────────────────────────────────────────────────────────────────
+    companion object {
+        @Volatile
+        private var INSTANCE: NearbyParkingRepository? = null
+
+        fun getInstance(context: Context): NearbyParkingRepository {
+            return INSTANCE ?: synchronized(this) {
+                val instance = NearbyParkingRepository(context.applicationContext)
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/home/HomeScreen.kt
@@ -1,17 +1,30 @@
 package com.example.sd_smart_parking_app.ui.screens.home
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.example.sd_smart_parking_app.data.NetworkMonitor
 import com.example.sd_smart_parking_app.data.model.Floor
 import com.example.sd_smart_parking_app.ui.components.FloorRecommendationCard
@@ -20,6 +33,11 @@ import com.example.sd_smart_parking_app.ui.components.OfflineBanner
 import com.example.sd_smart_parking_app.ui.components.ParkingCard
 import com.example.sd_smart_parking_app.ui.components.WeatherCard
 import com.example.sd_smart_parking_app.ui.theme.BackgroundWhite
+import com.example.sd_smart_parking_app.ui.theme.CornerRadius
+import com.example.sd_smart_parking_app.ui.theme.DarkText
+import com.example.sd_smart_parking_app.ui.theme.MediumAvailabilityOrange
+import com.example.sd_smart_parking_app.ui.theme.MediumGray
+import com.example.sd_smart_parking_app.ui.theme.PrimaryYellow
 import com.example.sd_smart_parking_app.ui.theme.SmartParkingTheme
 import com.example.sd_smart_parking_app.ui.theme.Spacing
 import com.example.sd_smart_parking_app.ui.theme.Typography
@@ -33,6 +51,7 @@ import java.util.*
 @Composable
 fun HomeScreen(
     onNavigationClick: () -> Unit,
+    onNearbyParkingClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -134,6 +153,11 @@ fun HomeScreen(
                 modifier = Modifier.padding(horizontal = Spacing.lg, vertical = Spacing.md)
             )
 
+            NearbyParkingBanner(
+                onClick = onNearbyParkingClick,
+                isHighOccupancy = occupancyPercentageDisplay >= 70
+            )
+
             FloorRecommendationCard(
                 recommendation = recommendationState.recommendation,
                 isLoading = recommendationState.isLoading,
@@ -162,10 +186,53 @@ fun HomeScreen(
     }
 }
 
+@Composable
+private fun NearbyParkingBanner(onClick: () -> Unit, isHighOccupancy: Boolean = false) {
+    val borderColor = if (isHighOccupancy) MediumAvailabilityOrange else Color(0xFFBDBDBD)
+    val bgColor = if (isHighOccupancy) Color(0xFFFFF3E0) else Color(0xFFF5F5F5)
+    val title = if (isHighOccupancy) "Parking is almost full" else "Looking for parking?"
+    val subtitle = "See alternative parking nearby"
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+        colors = CardDefaults.cardColors(containerColor = bgColor),
+        shape = RoundedCornerShape(CornerRadius.lg),
+        border = BorderStroke(1.dp, borderColor)
+    ) {
+        Row(
+            modifier = Modifier.padding(Spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(title, style = Typography.headlineSmall)
+                Text(subtitle, style = Typography.bodySmall, color = MediumGray)
+            }
+            Button(
+                onClick = onClick,
+                modifier = Modifier.wrapContentWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = PrimaryYellow,
+                    contentColor = DarkText
+                ),
+                shape = RoundedCornerShape(CornerRadius.lg),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                    horizontal = Spacing.md,
+                    vertical = Spacing.sm
+                )
+            ) {
+                Text("View", style = Typography.labelLarge)
+            }
+        }
+    }
+}
+
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun HomeScreenPreview() {
     SmartParkingTheme {
-        HomeScreen(onNavigationClick = {})
+        HomeScreen(onNavigationClick = {}, onNearbyParkingClick = {})
     }
 }

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/navigation/NavGraph.kt
@@ -26,6 +26,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.example.sd_smart_parking_app.ui.screens.notes.ParkingNotesScreen
 import com.example.sd_smart_parking_app.ui.screens.stats.ParkingStatsScreen
 import com.example.sd_smart_parking_app.ui.screens.costbreakdown.CostBreakdownScreen
+import com.example.sd_smart_parking_app.ui.screens.nearbyparking.NearbyParkingScreen
 
 // Rutas de navegación
 object NavRoutes {
@@ -41,6 +42,7 @@ object NavRoutes {
     const val PARKING_NOTES = "parking_notes"
     const val PARKING_STATS = "parking_stats"
     const val COST_BREAKDOWN = "cost_breakdown"
+    const val NEARBY_PARKING = "nearby_parking"
 }
 
 @Composable
@@ -127,6 +129,9 @@ fun SmartParkingNavGraph(
                         launchSingleTop = true
                         restoreState = true
                     }
+                },
+                onNearbyParkingClick = {
+                    navController.navigate(NavRoutes.NEARBY_PARKING)
                 }
             )
         }
@@ -179,6 +184,12 @@ fun SmartParkingNavGraph(
                 onNavigateBack = {
                     navController.popBackStack()
                 }
+            )
+        }
+
+        composable(NavRoutes.NEARBY_PARKING) {
+            NearbyParkingScreen(
+                onNavigateBack = { navController.popBackStack() }
             )
         }
     }

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/nearbyparking/NearbyParkingScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/nearbyparking/NearbyParkingScreen.kt
@@ -1,0 +1,387 @@
+package com.example.sd_smart_parking_app.ui.screens.nearbyparking
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.sd_smart_parking_app.data.model.NearbyParking
+import com.example.sd_smart_parking_app.ui.components.PrimaryButton
+import com.example.sd_smart_parking_app.ui.theme.CornerRadius
+import com.example.sd_smart_parking_app.ui.theme.DarkText
+import com.example.sd_smart_parking_app.ui.theme.Elevation
+import com.example.sd_smart_parking_app.ui.theme.HighAvailabilityGreen
+import com.example.sd_smart_parking_app.ui.theme.LowAvailabilityRed
+import com.example.sd_smart_parking_app.ui.theme.MediumAvailabilityOrange
+import com.example.sd_smart_parking_app.ui.theme.MediumGray
+import com.example.sd_smart_parking_app.ui.theme.PrimaryYellow
+import com.example.sd_smart_parking_app.ui.theme.SmartParkingTheme
+import com.example.sd_smart_parking_app.ui.theme.Spacing
+import com.example.sd_smart_parking_app.ui.theme.Typography
+import com.example.sd_smart_parking_app.ui.theme.White
+import com.example.sd_smart_parking_app.viewmodel.DataSource
+import com.example.sd_smart_parking_app.viewmodel.NearbyParkingUiState
+import com.example.sd_smart_parking_app.viewmodel.NearbyParkingViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun NearbyParkingScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val viewModel: NearbyParkingViewModel = viewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.loadNearbyParking() }
+
+    NearbyParkingContent(
+        uiState = uiState,
+        onNavigateBack = onNavigateBack,
+        onRefresh = { viewModel.loadNearbyParking() },
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun NearbyParkingContent(
+    uiState: NearbyParkingUiState,
+    onNavigateBack: () -> Unit,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Nearby Parking",
+                        style = Typography.headlineMedium,
+                        color = DarkText
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = DarkText
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onRefresh) {
+                        Icon(
+                            imageVector = Icons.Default.Refresh,
+                            contentDescription = "Refresh",
+                            tint = DarkText
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = PrimaryYellow,
+                    titleContentColor = DarkText,
+                    navigationIconContentColor = DarkText,
+                    actionIconContentColor = DarkText
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            // Data source banner — shown when data is not fresh
+            if (uiState.dataSource != DataSource.FRESH && !uiState.isLoading) {
+                DataSourceBanner(
+                    dataSource = uiState.dataSource,
+                    savedAtMs = uiState.savedAtMs
+                )
+            }
+
+            when {
+                uiState.isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(color = PrimaryYellow)
+                    }
+                }
+
+                uiState.parkingList.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(Spacing.md)
+                        ) {
+                            Text(text = "🅿️", fontSize = 48.sp)
+                            Text(
+                                text = "No nearby parking found",
+                                style = Typography.bodyMedium,
+                                color = MediumGray
+                            )
+                            PrimaryButton(
+                                text = "Retry",
+                                onClick = onRefresh,
+                                modifier = Modifier
+                                    .padding(horizontal = Spacing.xxl)
+                                    .width(200.dp)
+                            )
+                        }
+                    }
+                }
+
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(Spacing.md),
+                        verticalArrangement = Arrangement.spacedBy(Spacing.md)
+                    ) {
+                        items(uiState.parkingList) { parking ->
+                            NearbyParkingCard(parking = parking)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DataSourceBanner(
+    dataSource: DataSource,
+    savedAtMs: Long
+) {
+    val (backgroundColor, message) = when (dataSource) {
+        DataSource.CACHE -> {
+            val minutesAgo = ((System.currentTimeMillis() - savedAtMs) / 60000).toInt()
+                .coerceAtLeast(0)
+            Pair(
+                Color(0xFFFFF8E1),
+                "⏱ Showing recent data · Updated $minutesAgo min ago"
+            )
+        }
+        DataSource.LOCAL_STORAGE -> {
+            val formatted = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+                .format(Date(savedAtMs))
+            Pair(
+                Color(0xFFFFF3E0),
+                "📦 Offline · Last saved $formatted"
+            )
+        }
+        DataSource.NONE -> Pair(
+            Color(0xFFFFEBEE),
+            "❌ No data available"
+        )
+        DataSource.FRESH -> return
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.md, vertical = Spacing.xs)
+    ) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = backgroundColor),
+            shape = RoundedCornerShape(CornerRadius.md)
+        ) {
+            Text(
+                text = message,
+                style = Typography.bodySmall,
+                modifier = Modifier.padding(Spacing.md)
+            )
+        }
+    }
+}
+
+@Composable
+private fun NearbyParkingCard(parking: NearbyParking) {
+    val context = LocalContext.current
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(CornerRadius.lg),
+        elevation = CardDefaults.cardElevation(defaultElevation = Elevation.sm),
+        colors = CardDefaults.cardColors(containerColor = White)
+    ) {
+        Column(modifier = Modifier.padding(Spacing.md)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = parking.name,
+                        style = Typography.headlineSmall
+                    )
+                    Text(
+                        text = parking.address,
+                        style = Typography.bodySmall,
+                        color = MediumGray
+                    )
+                }
+                AvailabilityBadge(capacity = parking.approximateCapacity)
+            }
+
+            Spacer(modifier = Modifier.height(Spacing.sm))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.lg)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.DirectionsCar,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = MediumGray
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.xs))
+                    Text(
+                        text = "${parking.distanceMeters.toInt()} m away",
+                        style = Typography.bodySmall
+                    )
+                }
+                if (parking.phone.isNotEmpty()) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Phone,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MediumGray
+                        )
+                        Spacer(modifier = Modifier.width(Spacing.xs))
+                        Text(
+                            text = parking.phone,
+                            style = Typography.bodySmall
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(Spacing.sm))
+
+            PrimaryButton(
+                text = "How to get there",
+                onClick = {
+                    val uri = Uri.parse("google.navigation:q=${parking.lat},${parking.lng}")
+                    val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+                        setPackage("com.google.android.apps.maps")
+                    }
+                    context.startActivity(intent)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun AvailabilityBadge(capacity: Int) {
+    val (backgroundColor, label) = when {
+        capacity > 50 -> Pair(HighAvailabilityGreen, "High")
+        capacity >= 20 -> Pair(MediumAvailabilityOrange, "Medium")
+        else -> Pair(LowAvailabilityRed, "Low")
+    }
+
+    Box(
+        modifier = Modifier.padding(start = Spacing.sm)
+    ) {
+        Card(
+            shape = RoundedCornerShape(CornerRadius.sm),
+            colors = CardDefaults.cardColors(containerColor = backgroundColor)
+        ) {
+            Text(
+                text = label,
+                style = Typography.labelSmall,
+                color = White,
+                modifier = Modifier.padding(
+                    horizontal = Spacing.xs,
+                    vertical = Spacing.xs
+                )
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+private fun NearbyParkingScreenPreview() {
+    val mockParkingList = listOf(
+        NearbyParking(
+            id = "parking_calle_19",
+            name = "Parqueadero Calle 19",
+            address = "Cl. 19 #3-16, Bogotá",
+            lat = 4.60098,
+            lng = -74.06521,
+            approximateCapacity = 80,
+            phone = "+57 1 234 5678",
+            distanceMeters = 560f
+        ),
+        NearbyParking(
+            id = "parking_eje_ambiental",
+            name = "Parqueadero Eje Ambiental",
+            address = "Av. Jiménez #3-50, Bogotá",
+            lat = 4.60201,
+            lng = -74.06874,
+            approximateCapacity = 35,
+            phone = "+57 1 456 7890",
+            distanceMeters = 280f
+        )
+    )
+    SmartParkingTheme {
+        NearbyParkingContent(
+            uiState = NearbyParkingUiState(
+                parkingList = mockParkingList,
+                isLoading = false,
+                dataSource = DataSource.FRESH
+            ),
+            onNavigateBack = {},
+            onRefresh = {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/NearbyParkingViewModel.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/NearbyParkingViewModel.kt
@@ -1,0 +1,107 @@
+package com.example.sd_smart_parking_app.viewmodel
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.sd_smart_parking_app.data.model.NearbyParking
+import com.example.sd_smart_parking_app.data.repository.NearbyParkingRepository
+import com.example.sd_smart_parking_app.data.repository.NearbyParkingResult
+import com.example.sd_smart_parking_app.utils.NetworkMonitor
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class NearbyParkingUiState(
+    val parkingList: List<NearbyParking> = emptyList(),
+    val isLoading: Boolean = false,
+    val dataSource: DataSource = DataSource.NONE,
+    val savedAtMs: Long = 0L,
+    val errorMessage: String? = null
+)
+
+enum class DataSource { FRESH, CACHE, LOCAL_STORAGE, NONE }
+
+class NearbyParkingViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository = NearbyParkingRepository.getInstance(application)
+    private val networkMonitor = NetworkMonitor(application)
+
+    private val _uiState = MutableStateFlow(NearbyParkingUiState())
+    val uiState: StateFlow<NearbyParkingUiState> = _uiState.asStateFlow()
+
+    init {
+        // Collect network state — auto-refresh when connectivity is restored
+        viewModelScope.launch {
+            var previousState: Boolean? = null
+            networkMonitor.networkStateFlow.collect { isOnline ->
+                Log.d("NearbyParkingVM", "Network state changed: $isOnline (previous: $previousState)")
+                if (previousState == false && isOnline) {
+                    Log.d("NearbyParkingVM", "Connectivity restored — refreshing nearby parking")
+                    loadNearbyParking()
+                }
+                previousState = isOnline
+            }
+        }
+    }
+
+    fun loadNearbyParking() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            Log.d("NearbyParkingVM", "loadNearbyParking started on: ${Thread.currentThread().name}")
+
+            when (val result = repository.getNearbyParking()) {
+                is NearbyParkingResult.Fresh -> {
+                    Log.d("NearbyParkingVM", "Result: Fresh — ${result.data.size} items")
+                    _uiState.update {
+                        it.copy(
+                            parkingList = result.data,
+                            isLoading = false,
+                            dataSource = DataSource.FRESH,
+                            savedAtMs = 0L,
+                            errorMessage = null
+                        )
+                    }
+                }
+                is NearbyParkingResult.FromCache -> {
+                    Log.d("NearbyParkingVM", "Result: FromCache — ${result.data.size} items, savedAt=${result.savedAtMs}")
+                    _uiState.update {
+                        it.copy(
+                            parkingList = result.data,
+                            isLoading = false,
+                            dataSource = DataSource.CACHE,
+                            savedAtMs = result.savedAtMs,
+                            errorMessage = null
+                        )
+                    }
+                }
+                is NearbyParkingResult.FromLocalStorage -> {
+                    Log.d("NearbyParkingVM", "Result: FromLocalStorage — ${result.data.size} items, savedAt=${result.savedAtMs}")
+                    _uiState.update {
+                        it.copy(
+                            parkingList = result.data,
+                            isLoading = false,
+                            dataSource = DataSource.LOCAL_STORAGE,
+                            savedAtMs = result.savedAtMs,
+                            errorMessage = null
+                        )
+                    }
+                }
+                is NearbyParkingResult.NoData -> {
+                    Log.d("NearbyParkingVM", "Result: NoData")
+                    _uiState.update {
+                        it.copy(
+                            parkingList = emptyList(),
+                            isLoading = false,
+                            dataSource = DataSource.NONE,
+                            savedAtMs = 0L,
+                            errorMessage = "No nearby parking data available"
+                        )
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

## Description

### What does this PR do?

Adds a new NearbyParkingScreen that shows alternative parking lots near the Universidad de los Andes SD building, accessible from the Home screen at any time. When occupancy reaches ≥ 70%, the entry banner changes its appearance to alert the user

### Why is this change needed?

Users need an alternative when the SD parking lot is full or nearly full. This feature gives them nearby options with distance, contact info, and direct Google Maps navigation — even when offline

### How was it implemented?

Four academic strategies were implemented simultaneously:

Multi-threading (Kotlin Coroutines): Two parallel async coroutines inside a coroutineScope — parkingJob on Dispatchers.IO (Firestore fetch) and distanceJob on Dispatchers.Default (Haversine distance calculation via Location.distanceBetween). Thread names are logged for demonstration.
In-memory cache (LruCache): LruCache<String, Pair<List<NearbyParking>, Long>>(1) with a 10-minute TTL, following the same pattern as OccupancyRepository.
Local storage (SharedPreferences): Parking list serialized as JSONArray/JSONObject (no new dependencies). distanceMeters is intentionally excluded and recalculated on every load.
Eventual connectivity ("Network falling back to cache"): Priority chain: Firestore → LruCache → SharedPreferences → NoData. The ViewModel also auto-refreshes when connectivity is restored (false → true transition via utils/NetworkMonitor).


Files created: NearbyParking.kt, NearbyParkingRepository.kt, NearbyParkingViewModel.kt, NearbyParkingScreen.kt

Files modified: NavGraph.kt, HomeScreen.kt

## Related Issue
Closes #52 

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build changes
- [ ] Tests

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

**Test configuration:**
- Device/OS: Xiaomi Redmi Note 12 Pro — Android
- Branch: feat/52-implement-new-view-and-feature-nearbyparkingscreen

Manual scenarios verified:

Online — data loads fresh from Firestore, sorted by distance
Offline after first load — LruCache serves data within 10-minute TTL
Offline after TTL expires — SharedPreferences fallback shown with "Last saved" timestamp
Reconnection — screen auto-refreshes when network is restored
Home screen banner visible at any occupancy; changes style at ≥ 70%
"How to get there" opens Google Maps navigation correctly


## Checklist
- [x] I have performed a self-review of my own code
- [x] My changes follow the code style of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have added/updated tests
- [x] My changes generate no new warnings
- [x] I have updated the documentation accordingly
- [x] Any dependent changes have been merged and published