### PR TITLE
refactor: optimize loops and regex initialization in NearbyParkingRep…

### DIFF
--- a/app/src/main/java/com/example/sd_smart_parking_app/data/repository/NearbyParkingRepository.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/repository/NearbyParkingRepository.kt
@@ -99,7 +99,8 @@ class NearbyParkingRepository private constructor(private val context: Context) 
 
     private fun saveToSharedPreferences(list: List<NearbyParking>) {
         val array = JSONArray()
-        list.forEach { parking ->
+        for (i in 0 until list.size) {  // ✅ indexed loop, sin Iterator
+            val parking = list[i]
             val obj = JSONObject().apply {
                 put("id", parking.id)
                 put("name", parking.name)
@@ -108,7 +109,6 @@ class NearbyParkingRepository private constructor(private val context: Context) 
                 put("lng", parking.lng)
                 put("approximateCapacity", parking.approximateCapacity)
                 put("phone", parking.phone)
-                // distanceMeters is NOT persisted — recalculated on load
             }
             array.put(obj)
         }
@@ -116,7 +116,6 @@ class NearbyParkingRepository private constructor(private val context: Context) 
             .putString("nearby_parking_json", array.toString())
             .putLong("nearby_parking_saved_at", System.currentTimeMillis())
             .apply()
-        Log.d("NearbyParkingRepo", "SharedPreferences updated — ${list.size} items saved")
     }
 
     private fun loadFromSharedPreferences(): List<NearbyParking>? {
@@ -151,11 +150,17 @@ class NearbyParkingRepository private constructor(private val context: Context) 
     // Distance helpers
     // ─────────────────────────────────────────────────────────────────────────
     private fun withDistances(list: List<NearbyParking>): List<NearbyParking> {
-        return list.map { parking ->
-            val results = FloatArray(1)
-            android.location.Location.distanceBetween(SD_LAT, SD_LNG, parking.lat, parking.lng, results)
-            parking.copy(distanceMeters = results[0])
-        }.sortedBy { it.distanceMeters }
+        val results = FloatArray(1)  // ✅ fuera del loop
+        val output = ArrayList<NearbyParking>(list.size)
+        for (i in 0 until list.size) {  // ✅ indexed loop
+            val parking = list[i]
+            android.location.Location.distanceBetween(
+                SD_LAT, SD_LNG, parking.lat, parking.lng, results
+            )
+            output.add(parking.copy(distanceMeters = results[0]))
+        }
+        output.sortBy { it.distanceMeters }
+        return output
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/register/RegisterScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/register/RegisterScreen.kt
@@ -61,9 +61,9 @@ fun RegisterScreen(
     val roles = listOf("Driver", "Manager")
 
     // Validation Regex
-    val emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[a-z]{2,}$".toRegex()
-    val plateRegex = "^[A-Z]{3}[0-9]{3}$".toRegex()
-    val phoneRegex = "^[0-9]{8,15}$".toRegex()
+    val emailRegex = remember { "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[a-z]{2,}$".toRegex() }
+    val plateRegex = remember { "^[A-Z]{3}[0-9]{3}$".toRegex() }
+    val phoneRegex = remember { "^[0-9]{8,15}$".toRegex() }
 
     // Validation logic
     val isEmailValid = email.matches(emailRegex)


### PR DESCRIPTION
## Description
### What does this PR do?
Applies three micro-optimizations to `RegisterScreen.kt` and `NearbyParkingRepository.kt` to reduce unnecessary heap allocations and GC pressure during user interaction and parking data processing.

### Why is this change needed?
Profiler analysis using Android Studio's Java/Kotlin Allocations tracker identified unnecessary object creation in two critical paths:
- `RegisterScreen` was creating 3 new `Regex` objects on every recomposition triggered by user keystrokes, generating 15+ short-lived allocations per form interaction and increasing GC pressure during registration.
- `NearbyParkingRepository.withDistances()` was allocating a new `FloatArray(1)` inside the loop body on every iteration, producing O(N) allocations per call instead of O(1).
- `NearbyParkingRepository.saveToSharedPreferences()` was using `forEach` on a `List`, which allocates an implicit `Iterator` object on every invocation.

### How was it implemented?
Three targeted changes following the micro-optimization principles covered in class:

**Optimization #1 — `RegisterScreen.kt`:** Wrapped the three `Regex` instances (`emailRegex`, `plateRegex`, `phoneRegex`) in `remember { }` so they are created once during the Composable lifecycle and reused across all recompositions. Validated with the Java/Kotlin Allocations profiler: `kotlin.text.Regex` allocations dropped from **15 to 0** during a 5-keystroke recording session.

**Optimization #1 (loop) — `NearbyParkingRepository.kt` — `withDistances()`:** Moved `FloatArray(1)` outside the loop so it is allocated once and reused across all iterations. Replaced `.map{}.sortedBy{}` (two intermediate lists) with a pre-sized `ArrayList` and an in-place `sortBy`, eliminating O(N) intermediate allocations. An indirect reduction in `float[][]` allocations (18 → 6) was observed in the profiler, consistent with the removal of the intermediate list operations.

**Optimization #4 — `NearbyParkingRepository.kt` — `saveToSharedPreferences()`:** Replaced `forEach` with an indexed `for (i in 0 until list.size)` loop, eliminating the implicit `Iterator` object allocated by the `forEach` extension function on each call.

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build changes
- [ ] Tests

## How Has This Been Tested?
Micro-optimizations were validated using Android Studio Profiler — **Track Memory Consumption (Java/Kotlin Allocations)**:

- **Regex optimization:** recorded while typing 5 characters in the email field on `RegisterScreen`. `kotlin.text.Regex` allocations: 15 (before) → 0 (after).
- **FloatArray and forEach optimizations:** recorded while opening `NearbyParkingScreen` from a cold LruCache state. `float[][]` allocations: 18 (before) → 6 (after). `float[]` totals are dominated by system-wide noise (Google Maps SDK, sensors) at the current dataset size of 3 parking locations, making repository-specific allocations non-isolatable at aggregate level.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

**Test configuration:**
- Device/OS: Redmi Note 12 Pro
- Branch:  refactor/58-implementing-micro-optimizations 
## Screenshots (if applicable)

## Checklist
- [x] I have performed a self-review of my own code
- [x] My changes follow the code style of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have added/updated tests
- [x] My changes generate no new warnings
- [x] I have updated the documentation accordingly
- [ ] Any dependent changes have been merged and published