### PR TITLE
Refactor/58 implementing micro optimizations

### DIFF
--- a/app/src/main/java/com/example/sd_smart_parking_app/data/repository/NearbyParkingRepository.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/data/repository/NearbyParkingRepository.kt
@@ -99,7 +99,8 @@ class NearbyParkingRepository private constructor(private val context: Context) 
 
     private fun saveToSharedPreferences(list: List<NearbyParking>) {
         val array = JSONArray()
-        list.forEach { parking ->
+        for (i in 0 until list.size) {  // ✅ indexed loop, sin Iterator
+            val parking = list[i]
             val obj = JSONObject().apply {
                 put("id", parking.id)
                 put("name", parking.name)
@@ -108,7 +109,6 @@ class NearbyParkingRepository private constructor(private val context: Context) 
                 put("lng", parking.lng)
                 put("approximateCapacity", parking.approximateCapacity)
                 put("phone", parking.phone)
-                // distanceMeters is NOT persisted — recalculated on load
             }
             array.put(obj)
         }
@@ -116,7 +116,6 @@ class NearbyParkingRepository private constructor(private val context: Context) 
             .putString("nearby_parking_json", array.toString())
             .putLong("nearby_parking_saved_at", System.currentTimeMillis())
             .apply()
-        Log.d("NearbyParkingRepo", "SharedPreferences updated — ${list.size} items saved")
     }
 
     private fun loadFromSharedPreferences(): List<NearbyParking>? {
@@ -151,11 +150,17 @@ class NearbyParkingRepository private constructor(private val context: Context) 
     // Distance helpers
     // ─────────────────────────────────────────────────────────────────────────
     private fun withDistances(list: List<NearbyParking>): List<NearbyParking> {
-        return list.map { parking ->
-            val results = FloatArray(1)
-            android.location.Location.distanceBetween(SD_LAT, SD_LNG, parking.lat, parking.lng, results)
-            parking.copy(distanceMeters = results[0])
-        }.sortedBy { it.distanceMeters }
+        val results = FloatArray(1)  // ✅ fuera del loop
+        val output = ArrayList<NearbyParking>(list.size)
+        for (i in 0 until list.size) {  // ✅ indexed loop
+            val parking = list[i]
+            android.location.Location.distanceBetween(
+                SD_LAT, SD_LNG, parking.lat, parking.lng, results
+            )
+            output.add(parking.copy(distanceMeters = results[0]))
+        }
+        output.sortBy { it.distanceMeters }
+        return output
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/register/RegisterScreen.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/ui/screens/register/RegisterScreen.kt
@@ -61,9 +61,9 @@ fun RegisterScreen(
     val roles = listOf("Driver", "Manager")
 
     // Validation Regex
-    val emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[a-z]{2,}$".toRegex()
-    val plateRegex = "^[A-Z]{3}[0-9]{3}$".toRegex()
-    val phoneRegex = "^[0-9]{8,15}$".toRegex()
+    val emailRegex = remember { "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[a-z]{2,}$".toRegex() }
+    val plateRegex = remember { "^[A-Z]{3}[0-9]{3}$".toRegex() }
+    val phoneRegex = remember { "^[0-9]{8,15}$".toRegex() }
 
     // Validation logic
     val isEmailValid = email.matches(emailRegex)

--- a/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/SharedDetailsViewModel.kt
+++ b/app/src/main/java/com/example/sd_smart_parking_app/viewmodel/SharedDetailsViewModel.kt
@@ -1,5 +1,7 @@
 package com.example.sd_smart_parking_app.viewmodel
 
+import android.util.Log
+import android.util.SparseArray
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.sd_smart_parking_app.data.model.ParkingConfig
@@ -43,6 +45,30 @@ class SharedDetailsViewModel(
 
     private var isInitialized = false
 
+    // ── SparseArray cache de FloorState ──────────────────────────────────────
+    // SparseArray es la estructura elegida porque las claves son enteros (número
+    // de piso). A diferencia de HashMap<Int, FloorState>, SparseArray evita el
+    // boxing/unboxing de Int a Integer en cada acceso, usando arrays de int[]
+    // internamente. Esto reduce allocations y es la recomendación de Android
+    // para mapas con claves enteras en rangos pequeños y conocidos.
+    //
+    // Decisión de tamaño: initialCapacity = 5 porque el parqueadero tiene un
+    // número fijo de pisos (configurado en Firebase). 5 es un valor razonable
+    // que evita reallocations en la mayoría de los casos sin desperdiciar memoria.
+    // El SparseArray puede crecer si hay más pisos.
+    //
+    // Clave   = número de piso (Int, ej: 1, 2, 3)
+    // Valor   = FloorState calculado para ese piso
+    // Política de invalidación: se invalida individualmente cuando cambia el
+    // número de spots disponibles en ese piso. Si el piso no cambió entre
+    // snapshots de Firestore, se reutiliza la entrada cacheada sin recalcular.
+    private val floorStateCache = SparseArray<FloorState>(5)
+
+    // Rastrea cuántos spots disponibles había por piso en el último snapshot.
+    // Permite detectar si un piso realmente cambió antes de recalcular su estado.
+    // Clave = número de piso, Valor = cantidad de spots disponibles
+    private val lastKnownAvailable = SparseArray<Int>(5)
+
     init {
         val savedTimestamp = repository.getLastServerUpdate()
         if (savedTimestamp > 0L) {
@@ -83,7 +109,6 @@ class SharedDetailsViewModel(
 
                 val displayTime = if (isFromCache) {
                     val savedTs = repository.getLastServerUpdate()
-                    // Use saved server timestamp if available; fall back to now so the label is never blank
                     if (savedTs > 0L) formatTimestamp(savedTs) else formatTimestamp(System.currentTimeMillis())
                 } else {
                     formatTimestamp(System.currentTimeMillis())
@@ -112,9 +137,25 @@ class SharedDetailsViewModel(
                 val spotsInFloor = spots.filter { it.floor == floorNum }
                 val floorTotal = spotsInFloor.size
                 val floorAvailable = spotsInFloor.count { it.isAvailable }
-                val floorPercentage = if (floorTotal > 0) (floorAvailable * 100) / floorTotal else 0
 
-                FloorState(
+                // ── Lógica de caché SparseArray ───────────────────────────────
+                // Verificar si el número de spots disponibles cambió respecto al
+                // último snapshot procesado para este piso.
+                val previousAvailable = lastKnownAvailable.get(floorNum, -1)
+                val floorChanged = previousAvailable != floorAvailable
+
+                if (!floorChanged) {
+                    // Cache HIT: el piso no cambió — reutilizar FloorState existente
+                    val cached = floorStateCache.get(floorNum)
+                    if (cached != null) {
+                        Log.d("FloorStateCache", "[SparseArray] HIT — piso $floorNum | available: $floorAvailable (sin cambios)")
+                        return@map cached
+                    }
+                }
+
+                // Cache MISS o piso cambió: recalcular FloorState
+                val floorPercentage = if (floorTotal > 0) (floorAvailable * 100) / floorTotal else 0
+                val newState = FloorState(
                     floorNumber = floorNum,
                     availableSpots = floorAvailable,
                     totalSpots = floorTotal,
@@ -125,6 +166,13 @@ class SharedDetailsViewModel(
                         else -> "Low"
                     }
                 )
+
+                // Actualizar caché y tracker de disponibilidad
+                floorStateCache.put(floorNum, newState)
+                lastKnownAvailable.put(floorNum, floorAvailable)
+                Log.d("FloorStateCache", "[SparseArray] MISS — piso $floorNum recalculado | prev: $previousAvailable → now: $floorAvailable | cache size: ${floorStateCache.size()}")
+
+                newState
             }
 
             _detailsState.value = _detailsState.value.copy(floorStates = newFloorStates)
@@ -132,6 +180,12 @@ class SharedDetailsViewModel(
     }
 
     fun refreshData() {
+        // Al forzar refresh desde el servidor, invalidar el caché completo
+        // para que todos los pisos se recalculen con datos frescos.
+        floorStateCache.clear()
+        lastKnownAvailable.clear()
+        Log.d("FloorStateCache", "[SparseArray] Cache invalidado por refresh manual")
+
         repository.forceRefreshParkingSpots(
             onResult = { spots, timestamp ->
                 val total = spots.size


### PR DESCRIPTION
## Description
### What does this PR do?
Adds a `SparseArray`-based floor state cache to `SharedDetailsViewModel` to avoid redundant recomputation of `FloorState` objects on every Firestore snapshot. Only floors whose available spot count has changed are recalculated; unchanged floors return a cached result directly.

### Why is this change needed?
The details screen subscribes to a real-time Firestore listener that fires on every parking spot change. Previously, every snapshot triggered a full recomputation of all floor states regardless of what actually changed. With a multi-floor parking lot receiving frequent updates, this created unnecessary CPU work on the main thread on every event.

### How was it implemented?
Two `SparseArray` structures were added to `SharedDetailsViewModel`:
- `floorStateCache: SparseArray<FloorState>` — stores the last computed `FloorState` per floor number
- `lastKnownAvailable: SparseArray<Int>` — tracks available spot count per floor to detect real changes between snapshots

On each snapshot, `updateFloorStates()` compares the incoming available count per floor against the last known value. If unchanged, it returns the cached `FloorState` (HIT). If changed, it recomputes and updates both arrays (MISS). On manual refresh, both arrays are cleared to force a full recomputation from fresh server data.

`SparseArray` was chosen over `HashMap<Int, V>` because floor numbers are integer keys in a small known range, allowing `SparseArray` to use primitive `int[]` arrays internally and avoid the boxing overhead of `Integer` objects.


## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build changes
- [ ] Tests

## How Has This Been Tested?
Manual testing via Logcat — cache HIT/MISS logs are emitted with tag `FloorStateCache` on every snapshot, confirming that only changed floors trigger recomputation.

- [x] Manual testing


## Checklist
- [x] I have performed a self-review of my own code
- [x] My changes follow the code style of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have added/updated tests
- [x] My changes generate no new warnings
- [ ] I have updated the documentation accordingly
- [ ] Any dependent changes have been merged and published
